### PR TITLE
Add precision about updatePomFile property in documentation

### DIFF
--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -195,6 +195,7 @@ public class FlattenMojo
      * this is only done for projects with packaging other than <code>pom</code>. You may want to also do this for
      * <code>pom</code> packages projects by setting this parameter to <code>true</code> or you can use
      * <code>false</code> in order to only generate the flattened POM but never set it as POM file.
+     * If <code>flattenMode</code> is set to bom the default value will be <code>true</code>.
      */
     @Parameter( property = "updatePomFile" )
     private Boolean updatePomFile;


### PR DESCRIPTION
The document does not specify that the `updatePomFile` property default value is set to `true` if the `flattenMode` is set to `bon`.
