### PR TITLE
Apply properties from profiles that are active by default

### DIFF
--- a/src/it/projects/property-in-version-from-profile/pom.xml
+++ b/src/it/projects/property-in-version-from-profile/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.flatten.its</groupId>
+  <artifactId>property-in-version-from-profile</artifactId>
+  <version>0.0.1.${revision}-SNAPSHOT</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <configuration>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <profiles>
+    <profile>
+      <id>default-revision</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <revision>0000</revision>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/src/it/projects/property-in-version-from-profile/verify.groovy
+++ b/src/it/projects/property-in-version-from-profile/verify.groovy
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File originalPom = new File( basedir, 'pom.xml' )
+assert originalPom.exists()
+
+def originalProject = new XmlSlurper().parse( originalPom )
+assert 'default-revision' == originalProject.profiles.profile.id.text()
+
+File flattendPom = new File( basedir, '.flattened-pom.xml' )
+assert flattendPom.exists()
+
+def flattendProject = new XmlSlurper().parse( flattendPom )
+assert '0.0.1.0000-SNAPSHOT' == flattendProject.version.text()
+

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -659,8 +659,14 @@ public class FlattenMojo
                 public void injectProfile( Model model, Profile profile, ModelBuildingRequest request,
                                            ModelProblemCollector problems )
                 {
-
-                    // do nothing
+                    // Apply properties from profiles that are active by default. They might be needed to resolve
+                    // my own version.
+                    if (profile.getActivation() != null && profile.getActivation().isActiveByDefault()) {
+                        Properties merged = new Properties();
+                        merged.putAll(profile.getProperties());
+                        merged.putAll(model.getProperties());
+                        model.setProperties(merged);
+                    }
                 }
             };
             ProfileSelector profileSelector = new ProfileSelector()


### PR DESCRIPTION
When using continuous delivery friendly version numbers with variables,
such variables can be either set externally (-D...) or via a profile
property. While the former works, the later does not. To fix this
properties from profiles that are active by default are now merged into
the effective model.
