### PR TITLE
Apply only over active profiles

### DIFF
--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -768,15 +768,13 @@ public class FlattenMojo
         {
             Model projectModel = this.project.getModel();
             Dependencies modelDependencies = new Dependencies();
-            modelDependencies.addAll( projectModel.getDependencies() );            
-            
-            //for ( Profile profile : projectModel.getProfiles() )            
+            modelDependencies.addAll( projectModel.getDependencies() );             
             for ( Profile profile : this.project.getActiveProfiles() )
             {            	            	
                 // build-time driven activation (by property or file)?
                 if ( isBuildTimeDriven( profile.getActivation() ) )
                 {           
-                	getLog().info( "Processing dependencies defined in profile:" + profile.getId());
+                	getLog().debug( "Processing dependencies defined in profile:" + profile.getId());
                     List<Dependency> profileDependencies = profile.getDependencies();
                     for ( Dependency profileDependency : profileDependencies )
                     {

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -768,12 +768,15 @@ public class FlattenMojo
         {
             Model projectModel = this.project.getModel();
             Dependencies modelDependencies = new Dependencies();
-            modelDependencies.addAll( projectModel.getDependencies() );
-            for ( Profile profile : projectModel.getProfiles() )
-            {
+            modelDependencies.addAll( projectModel.getDependencies() );            
+            
+            //for ( Profile profile : projectModel.getProfiles() )            
+            for ( Profile profile : this.project.getActiveProfiles() )
+            {            	            	
                 // build-time driven activation (by property or file)?
                 if ( isBuildTimeDriven( profile.getActivation() ) )
-                {
+                {           
+                	getLog().info( "Processing dependencies defined in profile:" + profile.getId());
                     List<Dependency> profileDependencies = profile.getDependencies();
                     for ( Dependency profileDependency : profileDependencies )
                     {


### PR DESCRIPTION
When the property embedBuildProfileDependencies = true all the dependencies defined in the profiles are moved to project general dependencies. If you have the same dependency in several profiles but maybe with other versions after the flatten process the result contains duplicated definitions.

With the change proposed only the active profiles will be taken into account.