### PR TITLE
Ci friendly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
               </properties>
               <goals>
                 <goal>clean</goal>
-                <goal>${project.groupId}:${project.artifactId}:${project.version}:flatten</goal>
+                <goal>${project.groupId}:${project.artifactId}:${project.version}:flatten -Drevision=1.2.3.4</goal>
               </goals>
               <projectsDirectory>src/it/projects</projectsDirectory>
               <postBuildHookScript>verify</postBuildHookScript>

--- a/src/it/mrm/repository/parent-depMngt-properties.pom
+++ b/src/it/mrm/repository/parent-depMngt-properties.pom
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.flatten.its</groupId>
+  <artifactId>parent-depMngt-properties</artifactId>
+  <version>2</version>
+  <packaging>pom</packaging>
+  
+  <properties>
+  	<dep.version>1.1</dep.version>
+  </properties>
+  
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.codehaus.mojo.flatten.its</groupId>
+        <artifactId>dep</artifactId>
+        <version>${dep.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>  
+</project>

--- a/src/it/projects/complete-multimodule-parent-pom-cifriendly/invoker.properties
+++ b/src/it/projects/complete-multimodule-parent-pom-cifriendly/invoker.properties
@@ -1,1 +1,0 @@
-invoker.mavenOpts = -Drevision=1.2.3.4

--- a/src/it/projects/complete-multimodule-parent-pom-cifriendly/invoker.properties
+++ b/src/it/projects/complete-multimodule-parent-pom-cifriendly/invoker.properties
@@ -1,0 +1,1 @@
+invoker.mavenOpts = -Drevision=1.2.3.4

--- a/src/it/projects/complete-multimodule-parent-pom-cifriendly/module-with-parent/pom.xml
+++ b/src/it/projects/complete-multimodule-parent-pom-cifriendly/module-with-parent/pom.xml
@@ -1,13 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.codehaus.mojo.flatten.its</groupId>
-	<artifactId>multimodule-module-with-parent-cifriendly</artifactId>
-	<version>${revision}</version>
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.flatten.its</groupId>
+  <artifactId>multimodule-module-with-parent-cifriendly</artifactId>
+  <version>${revision}</version>
 
-	<parent>
-		<groupId>org.codehaus.mojo.flatten.its</groupId>
-		<artifactId>complete-multimodule-parent-pom-cifriendly</artifactId>
-		<version>${revision}</version>
-	</parent>
+  <parent>
+    <groupId>org.codehaus.mojo.flatten.its</groupId>
+    <artifactId>complete-multimodule-parent-pom-cifriendly</artifactId>
+    <version>${revision}</version>
+  </parent>
 </project>

--- a/src/it/projects/complete-multimodule-parent-pom-cifriendly/module-with-parent/pom.xml
+++ b/src/it/projects/complete-multimodule-parent-pom-cifriendly/module-with-parent/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.codehaus.mojo.flatten.its</groupId>
+	<artifactId>multimodule-module-with-parent-cifriendly</artifactId>
+	<version>${revision}</version>
+
+	<parent>
+		<groupId>org.codehaus.mojo.flatten.its</groupId>
+		<artifactId>complete-multimodule-parent-pom-cifriendly</artifactId>
+		<version>${revision}</version>
+	</parent>
+</project>

--- a/src/it/projects/complete-multimodule-parent-pom-cifriendly/module/pom.xml
+++ b/src/it/projects/complete-multimodule-parent-pom-cifriendly/module/pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.codehaus.mojo.flatten.its</groupId>
+	<artifactId>multimodule-module-cifriendly</artifactId>
+	<version>${revision}</version>
+</project>

--- a/src/it/projects/complete-multimodule-parent-pom-cifriendly/pom.xml
+++ b/src/it/projects/complete-multimodule-parent-pom-cifriendly/pom.xml
@@ -1,0 +1,117 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<!-- required -->
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.codehaus.mojo.flatten.its</groupId>
+	<artifactId>complete-multimodule-parent-pom-cifriendly</artifactId>
+	<version>${revision}</version>
+	<packaging>pom</packaging>
+
+	<!-- banned -->
+	<build>
+		<defaultGoal>verify</defaultGoal>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<configuration>
+					<flattenMode>resolveCiFriendliesOnly</flattenMode>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<ciManagement>
+		<url>http://localhost</url>
+	</ciManagement>
+
+	<contributors>
+		<contributor>
+			<name>Robert Scholte</name>
+		</contributor>
+	</contributors>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.codehaus.mojo.flatten.its</groupId>
+				<artifactId>dep</artifactId>
+				<version>1.1</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<description>This project contains only required, pom specific and ignorable elements</description>
+
+	<developers>
+		<developer>
+			<id>hohwille</id>
+			<name>J&#246;rg Hohwiller</name>
+		</developer>
+	</developers>
+
+	<distributionManagement>
+		<downloadUrl>http://mojo.codehaus.org/downloads</downloadUrl>
+	</distributionManagement>
+
+	<inceptionYear>2014</inceptionYear>
+
+	<issueManagement>
+		<system>jira</system>
+		<url>http://jira.codehaus.org/browse/MOJO</url>
+	</issueManagement>
+
+	<mailingLists>
+		<mailingList>
+			<name>announce</name>
+		</mailingList>
+	</mailingLists>
+
+	<modules>
+		<module>module</module>
+		<module>module-with-parent</module>
+	</modules>
+
+	<name>Complete POM</name>
+	<organization>
+		<name>Codehaus</name>
+	</organization>
+
+	<parent>
+		<groupId>org.codehaus.mojo.flatten.its</groupId>
+		<artifactId>parent-depMngt</artifactId>
+		<version>2</version>
+	</parent>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>none</id>
+			<url>@repository.proxy.url@</url>
+		</pluginRepository>
+	</pluginRepositories>
+
+	<!-- this one is only required for maven-plugin packaging type -->
+	<prerequisites>
+		<maven>3.0</maven>
+	</prerequisites>
+
+	<properties>
+		<!-- Default revision -->
+		<revision>1.2.3.0</revision>
+
+		<key>value</key>
+	</properties>
+
+	<reporting>
+		<outputDirectory>target/site</outputDirectory>
+	</reporting>
+
+	<reports />
+
+	<scm>
+		<url>http://svn.codehaus.org/mojo</url>
+	</scm>
+
+	<url>http://mojo.codehaus.org</url>
+
+</project>

--- a/src/it/projects/complete-multimodule-parent-pom-cifriendly/verify.groovy
+++ b/src/it/projects/complete-multimodule-parent-pom-cifriendly/verify.groovy
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File originalPom = new File( basedir, 'pom.xml' )
+assert originalPom.exists()
+
+def originalProject = new XmlSlurper().parse( originalPom )
+// required and maven-plugin specific elements
+assert '4.0.0' ==  originalProject.modelVersion.text()
+assert 'org.codehaus.mojo.flatten.its' == originalProject.groupId.text()
+assert 'complete-multimodule-parent-pom-cifriendly' == originalProject.artifactId.text()
+assert '${revision}' == originalProject.version.text()
+assert 'pom' == originalProject.packaging.text()
+// banned elements for artifact
+assert 1 == originalProject.build.size()
+assert 1 == originalProject.ciManagement.size()
+assert 1 == originalProject.contributors.size()
+assert 1 == originalProject.dependencyManagement.size()
+assert 1 == originalProject.description.size()
+assert 1 == originalProject.developers.size()
+assert 1 == originalProject.distributionManagement.size()
+assert 1 == originalProject.issueManagement.size()
+assert 1 == originalProject.mailingLists.size()
+assert 1 == originalProject.modules.size()
+assert 1 == originalProject.name.size()
+assert 1 == originalProject.organization.size()
+assert 1 == originalProject.parent.size()
+assert 1 == originalProject.pluginRepositories.size()
+assert 1 == originalProject.prerequisites.size()
+assert 1 == originalProject.properties.size()
+assert 1 == originalProject.reporting.size()
+assert 1 == originalProject.reports.size()
+assert 1 == originalProject.scm.size()
+assert 1 == originalProject.url.size()
+
+// Parent module
+File flattendPom = new File( basedir, '.flattened-pom.xml' )
+assert flattendPom.exists()
+
+def flattendProject = new XmlSlurper().parse( flattendPom )
+// required elements
+assert '4.0.0' ==  flattendProject.modelVersion.text()
+assert 'org.codehaus.mojo.flatten.its' == flattendProject.groupId.text()
+assert 'complete-multimodule-parent-pom-cifriendly' == flattendProject.artifactId.text()
+assert '1.2.3.4' == flattendProject.version.text()
+assert 'pom' == originalProject.packaging.text()
+
+// Child module: module
+File flattendChildPom = new File( basedir, 'module/.flattened-pom.xml' )
+assert flattendChildPom.exists()
+
+def flattendChildProject = new XmlSlurper().parse( flattendChildPom )
+// required elements
+assert '4.0.0' ==  flattendChildProject.modelVersion.text()
+assert 'org.codehaus.mojo.flatten.its' == flattendChildProject.groupId.text()
+assert 'multimodule-module-cifriendly' == flattendChildProject.artifactId.text()
+assert '1.2.3.4' == flattendChildProject.version.text()
+
+// Child module: module-with-parent
+File flattendChildWithParentPom = new File( basedir, 'module-with-parent/.flattened-pom.xml' )
+assert flattendChildWithParentPom.exists()
+
+def flattendChildWithParentProject = new XmlSlurper().parse( flattendChildWithParentPom )
+// required elements
+assert '4.0.0' ==  flattendChildWithParentProject.modelVersion.text()
+assert 'org.codehaus.mojo.flatten.its' == flattendChildWithParentProject.groupId.text()
+assert 'multimodule-module-with-parent-cifriendly' == flattendChildWithParentProject.artifactId.text()
+assert '1.2.3.4' == flattendChildWithParentProject.version.text()
+assert '1.2.3.4' == flattendChildWithParentProject.parent.version.text()

--- a/src/it/projects/inherit-parent-dependencyManagement-cifriendly/invoker.properties
+++ b/src/it/projects/inherit-parent-dependencyManagement-cifriendly/invoker.properties
@@ -1,0 +1,1 @@
+invoker.mavenOpts = -Drevision=1.2.3.4

--- a/src/it/projects/inherit-parent-dependencyManagement-cifriendly/invoker.properties
+++ b/src/it/projects/inherit-parent-dependencyManagement-cifriendly/invoker.properties
@@ -1,1 +1,1 @@
-invoker.mavenOpts = -Drevision=1.2.3.4
+

--- a/src/it/projects/inherit-parent-dependencyManagement-cifriendly/pom.xml
+++ b/src/it/projects/inherit-parent-dependencyManagement-cifriendly/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.codehaus.mojo.flatten.its</groupId>
+		<artifactId>parent-depMngt-properties</artifactId>
+		<version>2</version>
+	</parent>
+	<artifactId>inherit-parent-dependencyManagement-cifriendly</artifactId>
+	<version>${revision}</version>
+	
+	<properties>
+		<test.version>2.0</test.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.codehaus.mojo.flatten.its</groupId>
+			<artifactId>dep</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.mojo.flatten.its</groupId>
+			<artifactId>test</artifactId>
+			<version>${test.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<defaultGoal>verify</defaultGoal>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<configuration>
+					<flattenMode>resolveCiFriendliesOnly</flattenMode>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/projects/inherit-parent-dependencyManagement-cifriendly/verify.groovy
+++ b/src/it/projects/inherit-parent-dependencyManagement-cifriendly/verify.groovy
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File originalPom = new File( basedir, 'pom.xml' )
+assert originalPom.exists()
+
+def originalProject = new XmlSlurper().parse( originalPom )
+assert 0 ==  originalProject.dependencies.dependency[0].version.size()
+
+File flattenedPom = new File( basedir, '.flattened-pom.xml' )
+assert flattenedPom.exists()
+
+def flattenedProject = new XmlSlurper().parse( flattenedPom )
+assert '1.2.3.4' ==  flattenedProject.version.text()
+assert 0 ==  flattenedProject.dependencies.dependency[0].version.size()
+assert '${test.version}' ==  flattenedProject.dependencies.dependency[1].version.text()

--- a/src/it/projects/resolve-properties-ci/invoker.properties
+++ b/src/it/projects/resolve-properties-ci/invoker.properties
@@ -1,0 +1,1 @@
+invoker.mavenOpts = -Drevision=1.2.3.4 -Drevision1=1.2.3.5 -Dsmall=small -Dsha1=abcdefg -Dchangelist=1,2,3,4

--- a/src/it/projects/resolve-properties-ci/pom.xml
+++ b/src/it/projects/resolve-properties-ci/pom.xml
@@ -1,0 +1,65 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.codehaus.mojo.flatten.its</groupId>
+	<artifactId>resolve-properties-ci</artifactId>
+	<version>${revision}</version>
+
+	<properties>
+		<depVersion>1.1</depVersion>
+		<utilVersion>3.2.1</utilVersion>
+		<revision.property>${revision}</revision.property>
+		<revision1.property>${revision1}</revision1.property>
+		<small.property>${small}</small.property>
+		<small1.property>${small1}</small1.property>
+		<changelist.property>${changelist}</changelist.property>
+		<sha1.property>${sha1}</sha1.property>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.codehaus.mojo.flatten.its</groupId>
+			<artifactId>dep</artifactId>
+			<version>${revision}</version>
+			<classifier>${small}</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.mojo.flatten.its</groupId>
+			<artifactId>dep</artifactId>
+			<version>1.2.3.1</version>
+			<classifier>${small1}</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.mojo.flatten.its</groupId>
+			<artifactId>dep</artifactId>
+			<version>revision</version>
+			<classifier>small2</classifier>
+		</dependency>
+	</dependencies>
+
+	<!-- banned -->
+	<build>
+		<defaultGoal>verify</defaultGoal>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<configuration>
+					<flattenMode>resolveCiFriendliesOnly</flattenMode>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<profile>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<properties>
+				<profilerevision>${revision}</profilerevision>
+				<profilerevision1>${revision1}</profilerevision1>
+			</properties>
+		</profile>
+	</profiles>
+</project>

--- a/src/it/projects/resolve-properties-ci/verify.groovy
+++ b/src/it/projects/resolve-properties-ci/verify.groovy
@@ -42,5 +42,5 @@ assert '${small1}' == flattenedProject.dependencies.dependency[1].classifier.tex
 assert 'revision' == flattenedProject.dependencies.dependency[2].version.text()
 assert 'small2' == flattenedProject.dependencies.dependency[2].classifier.text()
 
-assert '${revision}' == flattenedProject.profiles.profile.properties.profilerevision.text()
+assert '1.2.3.4' == flattenedProject.profiles.profile.properties.profilerevision.text()
 assert '${revision1}' == flattenedProject.profiles.profile.properties.profilerevision1.text()

--- a/src/it/projects/resolve-properties-ci/verify.groovy
+++ b/src/it/projects/resolve-properties-ci/verify.groovy
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+File originalPom = new File( basedir, 'pom.xml' )
+assert originalPom.exists()
+ 
+def originalProject = new XmlSlurper().parse( originalPom )
+assert '${revision}' == originalProject.dependencies.dependency[0].version.text()
+assert '${small}' == originalProject.dependencies.dependency[0].classifier.text()
+
+File flattenedPom = new File( basedir, '.flattened-pom.xml' )
+assert flattenedPom.exists()
+def flattenedProject = new XmlSlurper().parse( flattenedPom )
+
+
+assert '1.2.3.4' == flattenedProject.version.text()
+assert '1.2.3.4' == flattenedProject.dependencies.dependency[0].version.text()
+assert '${small}' == flattenedProject.dependencies.dependency[0].classifier.text()
+
+assert '1.2.3.1' == flattenedProject.dependencies.dependency[1].version.text()
+assert '${small1}' == flattenedProject.dependencies.dependency[1].classifier.text()
+
+assert 'revision' == flattenedProject.dependencies.dependency[2].version.text()
+assert 'small2' == flattenedProject.dependencies.dependency[2].classifier.text()
+
+assert '${revision}' == flattenedProject.profiles.profile.properties.profilerevision.text()
+assert '${revision1}' == flattenedProject.profiles.profile.properties.profilerevision1.text()

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMode.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMode.java
@@ -74,7 +74,7 @@ public enum FlattenMode
     /** Removes all {@link FlattenDescriptor optional POM elements} and dependencies. */
     fatjar,
     
-    /** Only resolves variables revision, sha and changelist. Keeps everything else. */
+    /** Only resolves variables revision, sha1 and changelist. Keeps everything else. */
     resolveCiFriendliesOnly;
 
 

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMode.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMode.java
@@ -74,7 +74,9 @@ public enum FlattenMode
     /** Removes all {@link FlattenDescriptor optional POM elements} and dependencies. */
     fatjar,
     
-    /** Only resolves variables revision, sha1 and changelist. Keeps everything else. */
+    /** Only resolves variables revision, sha1 and changelist. Keeps everything else. 
+     * See <a href="https://maven.apache.org/maven-ci-friendly.html">Maven CI Friendly</a> for further details. 
+     */
     resolveCiFriendliesOnly;
 
 

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMode.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMode.java
@@ -72,7 +72,11 @@ public enum FlattenMode
     clean,
 
     /** Removes all {@link FlattenDescriptor optional POM elements} and dependencies. */
-    fatjar;
+    fatjar,
+    
+    /** Only resolves variables revision, sha and changelist. Keeps everything else. */
+    resolveCiFriendliesOnly;
+
 
     /**
      * @return the {@link FlattenDescriptor} defined by this {@link FlattenMode}.
@@ -113,6 +117,33 @@ public enum FlattenMode
                 break;
             case fatjar:
                 descriptor.setDependencies( ElementHandling.remove );
+                break;
+            case resolveCiFriendliesOnly:
+                descriptor.setBuild( ElementHandling.interpolate );
+                descriptor.setCiManagement( ElementHandling.interpolate );
+                descriptor.setContributors( ElementHandling.interpolate );
+                descriptor.setDependencies( ElementHandling.interpolate );
+                descriptor.setDependencyManagement( ElementHandling.interpolate );
+                descriptor.setDescription( ElementHandling.interpolate );
+                descriptor.setDevelopers( ElementHandling.interpolate );
+                descriptor.setDistributionManagement( ElementHandling.interpolate );
+                descriptor.setInceptionYear( ElementHandling.interpolate );
+                descriptor.setIssueManagement( ElementHandling.interpolate );
+                descriptor.setMailingLists( ElementHandling.interpolate );
+                descriptor.setModules( ElementHandling.interpolate );
+                descriptor.setName( ElementHandling.interpolate );
+                descriptor.setOrganization( ElementHandling.interpolate );
+                descriptor.setParent( ElementHandling.resolve );
+                descriptor.setPluginManagement( ElementHandling.interpolate );
+                descriptor.setPluginRepositories( ElementHandling.interpolate );
+                descriptor.setPrerequisites( ElementHandling.interpolate );
+                descriptor.setProfiles( ElementHandling.interpolate );
+                descriptor.setProperties( ElementHandling.interpolate );
+                descriptor.setReporting( ElementHandling.interpolate );
+                descriptor.setRepositories( ElementHandling.interpolate );
+                descriptor.setScm( ElementHandling.interpolate );
+                descriptor.setUrl( ElementHandling.interpolate );
+                descriptor.setVersion( ElementHandling.resolve );
                 break;
             case clean:
                 // nothing to do...

--- a/src/main/java/org/codehaus/mojo/flatten/cifriendly/CiInterpolator.java
+++ b/src/main/java/org/codehaus/mojo/flatten/cifriendly/CiInterpolator.java
@@ -1,0 +1,50 @@
+package org.codehaus.mojo.flatten.cifriendly;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.building.ModelBuildingRequest;
+import org.apache.maven.model.building.ModelProblemCollector;
+
+/**
+* A shameless replacement of ModelInterpolator from maven-model-builder. 
+* Made because of class loading issues that ensued when using ModelInterpolator interface.
+*/
+public interface CiInterpolator
+{
+
+   /**
+    * Interpolates expressions in the specified model. Note that implementations are free to either interpolate the
+    * provided model directly or to create a clone of the model and interpolate the clone. Callers should always use
+    * the returned model and must not rely on the input model being updated.
+    *
+    * @param model The model to interpolate, must not be {@code null}.
+    * @param projectDir The project directory, may be {@code null} if the model does not belong to a local project but
+    *            to some artifact's metadata.
+    * @param request The model building request that holds further settings, must not be {@code null}.
+    * @param problems The container used to collect problems that were encountered, must not be {@code null}.
+    * @return The interpolated model, never {@code null}.
+    */
+   Model interpolateModel( Model model, File projectDir, ModelBuildingRequest request,
+                           ModelProblemCollector problems );
+
+}

--- a/src/main/java/org/codehaus/mojo/flatten/cifriendly/CiInterpolatorImpl.java
+++ b/src/main/java/org/codehaus/mojo/flatten/cifriendly/CiInterpolatorImpl.java
@@ -1,0 +1,351 @@
+package org.codehaus.mojo.flatten.cifriendly;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.codehaus.plexus.interpolation.InterpolationCycleException;
+import org.codehaus.plexus.interpolation.InterpolationException;
+import org.codehaus.plexus.interpolation.InterpolationPostProcessor;
+import org.codehaus.plexus.interpolation.Interpolator;
+import org.codehaus.plexus.interpolation.RecursionInterceptor;
+import org.codehaus.plexus.interpolation.SimpleRecursionInterceptor;
+import org.codehaus.plexus.interpolation.ValueSource;
+
+/*
+ * Based on StringSearchInterpolator from plexus-interpolation.
+ */
+public class CiInterpolatorImpl implements Interpolator {
+
+	    private Map existingAnswers = new HashMap();
+
+	    private List<ValueSource> valueSources = new ArrayList<ValueSource>();
+
+	    private List<InterpolationPostProcessor> postProcessors = new ArrayList<InterpolationPostProcessor>();
+
+	    private boolean cacheAnswers = false;
+
+	    public static final String DEFAULT_START_EXPR = "${";
+
+	    public static final String DEFAULT_END_EXPR = "}";
+
+	    private String startExpr;
+
+	    private String endExpr;
+
+	    private String escapeString;
+
+	    public CiInterpolatorImpl()
+	    {
+	        this.startExpr = DEFAULT_START_EXPR;
+	        this.endExpr = DEFAULT_END_EXPR;
+	    }
+
+	    public CiInterpolatorImpl( String startExpr, String endExpr )
+	    {
+	        this.startExpr = startExpr;
+	        this.endExpr = endExpr;
+	    }
+
+
+	    /**
+	     * {@inheritDoc}
+	     */
+	    public void addValueSource( ValueSource valueSource )
+	    {
+	        valueSources.add( valueSource );
+	    }
+
+	    /**
+	     * {@inheritDoc}
+	     */
+	    public void removeValuesSource( ValueSource valueSource )
+	    {
+	        valueSources.remove( valueSource );
+	    }
+
+	    /**
+	     * {@inheritDoc}
+	     */
+	    public void addPostProcessor( InterpolationPostProcessor postProcessor )
+	    {
+	        postProcessors.add( postProcessor );
+	    }
+
+	    /**
+	     * {@inheritDoc}
+	     */
+	    public void removePostProcessor( InterpolationPostProcessor postProcessor )
+	    {
+	        postProcessors.remove( postProcessor );
+	    }
+
+	    public String interpolate( String input, String thisPrefixPattern )
+	        throws InterpolationException
+	    {
+	        return interpolate( input, new SimpleRecursionInterceptor() );
+	    }
+
+	    public String interpolate( String input, String thisPrefixPattern, RecursionInterceptor recursionInterceptor )
+	        throws InterpolationException
+	    {
+	        return interpolate( input, recursionInterceptor );
+	    }
+
+	    public String interpolate( String input )
+	        throws InterpolationException
+	    {
+	        return interpolate( input, new SimpleRecursionInterceptor() );
+	    }
+
+	    /**
+	     * Entry point for recursive resolution of an expression and all of its
+	     * nested expressions.
+	     *
+	     * @todo Ensure unresolvable expressions don't trigger infinite recursion.
+	     */
+	    public String interpolate( String input, RecursionInterceptor recursionInterceptor )
+	        throws InterpolationException
+	    {
+	        try
+	        {
+	            return interpolate( input, recursionInterceptor, new HashSet<String>() );
+	        }
+	        finally
+	        {
+	            if ( !cacheAnswers )
+	            {
+	                existingAnswers.clear();
+	            }
+	        }
+	    }
+
+	    private String interpolate( String input, RecursionInterceptor recursionInterceptor, Set<String> unresolvable )
+	            throws InterpolationException
+	        {
+	            if ( input == null )
+	            {
+	                // return empty String to prevent NPE too
+	                return "";
+	            }
+	            StringBuilder result = new StringBuilder( input.length() * 2 );
+
+	            int startIdx;
+	            int endIdx = -1;
+	            while ( ( startIdx = input.indexOf( startExpr, endIdx + 1 ) ) > -1 )
+	            {
+	                result.append( input, endIdx + 1, startIdx );
+
+	                endIdx = input.indexOf( endExpr, startIdx + 1 );
+	                if ( endIdx < 0 )
+	                {
+	                    break;
+	                }
+
+	                final String wholeExpr = input.substring( startIdx, endIdx + endExpr.length() );
+	                String realExpr = wholeExpr.substring( startExpr.length(), wholeExpr.length() - endExpr.length() );
+
+	                if ( startIdx >= 0 && escapeString != null && escapeString.length() > 0 )
+	                {
+	                    int startEscapeIdx = startIdx == 0 ? 0 : startIdx - escapeString.length();
+	                    if ( startEscapeIdx >= 0 )
+	                    {
+	                        String escape = input.substring( startEscapeIdx, startIdx );
+	                        if ( escape != null && escapeString.equals( escape ) )
+	                        {
+	                            result.append( wholeExpr );
+	                            result.replace( startEscapeIdx, startEscapeIdx + escapeString.length(), "" );
+	                            continue;
+	                        }
+	                    }
+	                }
+
+	                boolean resolved = false;
+	                if ( !unresolvable.contains( wholeExpr ) )
+	                {
+	                    if ( realExpr.startsWith( "." ) )
+	                    {
+	                        realExpr = realExpr.substring( 1 );
+	                    }
+
+	                    if ( recursionInterceptor.hasRecursiveExpression( realExpr ) )
+	                    {
+	                        throw new InterpolationCycleException( recursionInterceptor, realExpr, wholeExpr );
+	                    }
+
+	                    recursionInterceptor.expressionResolutionStarted( realExpr );
+	                    try
+	                    {
+	                        Object value = existingAnswers.get( realExpr );
+	                        if (!wholeExpr.equals("${revision}")
+	                        	&& !wholeExpr.contains("${sha1}")
+	                        	&& !wholeExpr.contains("${changelist}")) {
+	                        	value = realExpr;
+	                        }
+	                        Object bestAnswer = null;
+
+	                        for ( ValueSource valueSource : valueSources )
+	                        {
+	                            if ( value != null )
+	                            {
+	                                break;
+	                            }
+	                            value = valueSource.getValue( realExpr );
+
+	                            if ( value != null && value.toString().contains( wholeExpr ) )
+	                            {
+	                                bestAnswer = value;
+	                                value = null;
+	                            }
+	                        }
+
+	                        // this is the simplest recursion check to catch exact recursion
+	                        // (non synonym), and avoid the extra effort of more string
+	                        // searching.
+	                        if ( value == null && bestAnswer != null )
+	                        {
+	                            throw new InterpolationCycleException( recursionInterceptor, realExpr, wholeExpr );
+	                        }
+
+	                        if ( value != null )
+	                        {
+	                            value = interpolate( String.valueOf( value ), recursionInterceptor, unresolvable );
+
+	                            if ( postProcessors != null && !postProcessors.isEmpty() )
+	                            {
+	                                for ( InterpolationPostProcessor postProcessor : postProcessors )
+	                                {
+	                                    Object newVal = postProcessor.execute( realExpr, value );
+	                                    if ( newVal != null )
+	                                    {
+	                                        value = newVal;
+	                                        break;
+	                                    }
+	                                }
+	                            }
+
+	                            // could use:
+	                            // result = matcher.replaceFirst( stringValue );
+	                            // but this could result in multiple lookups of stringValue, and replaceAll is not correct
+	                            // behaviour
+	                            result.append( String.valueOf( value ) );
+	                            resolved = true;
+	                        }
+	                        else
+	                        {
+	                            unresolvable.add( wholeExpr );
+	                        }
+	                    }
+	                    finally
+	                    {
+	                        recursionInterceptor.expressionResolutionFinished( realExpr );
+	                    }
+	                }
+
+	                if ( !resolved )
+	                {
+	                    result.append( wholeExpr );
+	                }
+
+	                if ( endIdx > -1 )
+	                {
+	                    endIdx += endExpr.length() - 1;
+	                }
+	            }
+
+	            if ( endIdx == -1 && startIdx > -1 )
+	            {
+	                result.append( input, startIdx, input.length());
+	            }
+	            else if ( endIdx < input.length() )
+	            {
+	                result.append( input, endIdx + 1, input.length() );
+	            }
+
+	            return result.toString();
+	        }
+
+	    /**
+	     * Return any feedback messages and errors that were generated - but
+	     * suppressed - during the interpolation process. Since unresolvable
+	     * expressions will be left in the source string as-is, this feedback is
+	     * optional, and will only be useful for debugging interpolation problems.
+	     *
+	     * @return a {@link List} that may be interspersed with {@link String} and
+	     *         {@link Throwable} instances.
+	     */
+	    public List getFeedback()
+	    {
+	        List<?> messages = new ArrayList();
+	        for ( ValueSource vs : valueSources )
+	        {
+	            List feedback = vs.getFeedback();
+	            if ( feedback != null && !feedback.isEmpty() )
+	            {
+	                messages.addAll( feedback );
+	            }
+	        }
+
+	        return messages;
+	    }
+
+	    /**
+	     * Clear the feedback messages from previous interpolate(..) calls.
+	     */
+	    public void clearFeedback()
+	    {
+	        for ( ValueSource vs : valueSources )
+	        {
+	            vs.clearFeedback();
+	        }
+	    }
+
+	    public boolean isCacheAnswers()
+	    {
+	        return cacheAnswers;
+	    }
+
+	    public void setCacheAnswers( boolean cacheAnswers )
+	    {
+	        this.cacheAnswers = cacheAnswers;
+	    }
+
+	    public void clearAnswers()
+	    {
+	        existingAnswers.clear();
+	    }
+
+	    public String getEscapeString()
+	    {
+	        return escapeString;
+	    }
+
+	    public void setEscapeString( String escapeString )
+	    {
+	        this.escapeString = escapeString;
+	    }
+
+	}
+

--- a/src/main/java/org/codehaus/mojo/flatten/cifriendly/CiInterpolatorImpl.java
+++ b/src/main/java/org/codehaus/mojo/flatten/cifriendly/CiInterpolatorImpl.java
@@ -35,7 +35,9 @@ import org.codehaus.plexus.interpolation.SimpleRecursionInterceptor;
 import org.codehaus.plexus.interpolation.ValueSource;
 
 /*
- * Based on StringSearchInterpolator from plexus-interpolation.
+ * Based on StringSearchInterpolator from plexus-interpolation,
+ * see {@link org.codehaus.plexus.interpolation.StringSearchInterpolator}.
+ * This interpolates only the Maven CI Friendly variables revision, sha1 and changelist.
  */
 public class CiInterpolatorImpl implements Interpolator {
 

--- a/src/main/java/org/codehaus/mojo/flatten/cifriendly/CiModelInterpolator.java
+++ b/src/main/java/org/codehaus/mojo/flatten/cifriendly/CiModelInterpolator.java
@@ -1,0 +1,683 @@
+package org.codehaus.mojo.flatten.cifriendly;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.building.ModelBuildingRequest;
+import org.apache.maven.model.building.ModelProblem.Severity;
+import org.apache.maven.model.building.ModelProblem.Version;
+import org.apache.maven.model.building.ModelProblemCollector;
+import org.apache.maven.model.building.ModelProblemCollectorRequest;
+import org.apache.maven.model.interpolation.MavenBuildTimestamp;
+import org.apache.maven.model.interpolation.ModelInterpolator;
+import org.apache.maven.model.path.PathTranslator;
+import org.apache.maven.model.path.UrlNormalizer;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.interpolation.AbstractValueSource;
+import org.codehaus.plexus.interpolation.InterpolationException;
+import org.codehaus.plexus.interpolation.InterpolationPostProcessor;
+import org.codehaus.plexus.interpolation.Interpolator;
+import org.codehaus.plexus.interpolation.MapBasedValueSource;
+import org.codehaus.plexus.interpolation.ObjectBasedValueSource;
+import org.codehaus.plexus.interpolation.PrefixAwareRecursionInterceptor;
+import org.codehaus.plexus.interpolation.PrefixedObjectValueSource;
+import org.codehaus.plexus.interpolation.PrefixedValueSourceWrapper;
+import org.codehaus.plexus.interpolation.RecursionInterceptor;
+import org.codehaus.plexus.interpolation.ValueSource;
+import org.codehaus.plexus.interpolation.util.ValueSourceUtils;
+
+/*
+ * Based on StringSearchModelInterpolator in maven-model-builder
+ */
+@Component(role = CiInterpolator.class)
+public class CiModelInterpolator implements CiInterpolator, ModelInterpolator {
+	
+    public CiModelInterpolator()
+    {
+        interpolator = createInterpolator();
+        recursionInterceptor = new PrefixAwareRecursionInterceptor( PROJECT_PREFIXES );
+    }
+
+	private static final List<String> PROJECT_PREFIXES = Arrays.asList("pom.", "project.");
+
+	private static final Collection<String> TRANSLATED_PATH_EXPRESSIONS;
+
+	static {
+		Collection<String> translatedPrefixes = new HashSet<String>();
+
+		// MNG-1927, MNG-2124, MNG-3355:
+		// If the build section is present and the project directory is
+		// non-null, we should make
+		// sure interpolation of the directories below uses translated paths.
+		// Afterward, we'll double back and translate any paths that weren't
+		// covered during interpolation via the
+		// code below...
+		translatedPrefixes.add("build.directory");
+		translatedPrefixes.add("build.outputDirectory");
+		translatedPrefixes.add("build.testOutputDirectory");
+		translatedPrefixes.add("build.sourceDirectory");
+		translatedPrefixes.add("build.testSourceDirectory");
+		translatedPrefixes.add("build.scriptSourceDirectory");
+		translatedPrefixes.add("reporting.outputDirectory");
+
+		TRANSLATED_PATH_EXPRESSIONS = translatedPrefixes;
+	}
+	private Interpolator interpolator;
+	private RecursionInterceptor recursionInterceptor;
+
+    @Requirement
+    private PathTranslator pathTranslator;
+
+    @Requirement
+    private UrlNormalizer urlNormalizer;
+
+	private static final Map<Class<?>, InterpolateObjectAction.CacheItem> CACHED_ENTRIES = new ConcurrentHashMap<Class<?>, InterpolateObjectAction.CacheItem>(
+			80, 0.75f, 2);
+	// Empirical data from 3.x, actual =40
+
+	public Model interpolateModel(Model model, File projectDir, ModelBuildingRequest config,
+			ModelProblemCollector problems) {
+		interpolateObject(model, model, projectDir, config, problems);
+
+		return model;
+	}
+
+	protected void interpolateObject(Object obj, Model model, File projectDir, ModelBuildingRequest config,
+			ModelProblemCollector problems) {
+		try {
+			List<? extends ValueSource> valueSources = createValueSources(model, projectDir, config, problems);
+			List<? extends InterpolationPostProcessor> postProcessors = createPostProcessors(model, projectDir, config);
+
+			InterpolateObjectAction action = new InterpolateObjectAction(obj, valueSources, postProcessors, this,
+					problems);
+
+			AccessController.doPrivileged(action);
+		} finally {
+			getInterpolator().clearAnswers();
+		}
+	}
+
+	protected String interpolateInternal(String src, List<? extends ValueSource> valueSources,
+			List<? extends InterpolationPostProcessor> postProcessors, ModelProblemCollector problems) {
+		if (src != null && !src.contains("${revision}") && !src.contains("${sha1}") && !src.contains("${changelist}")) {
+			return src;
+		}
+
+		String result = src;
+		synchronized (this) {
+
+			for (ValueSource vs : valueSources) {
+				getInterpolator().addValueSource(vs);
+			}
+
+			for (InterpolationPostProcessor postProcessor : postProcessors) {
+				getInterpolator().addPostProcessor(postProcessor);
+			}
+
+			try {
+				try {
+					result = getInterpolator().interpolate(result, getRecursionInterceptor());
+				} catch (InterpolationException e) {
+					problems.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE)
+							.setMessage(e.getMessage()).setException(e));
+				}
+
+				getInterpolator().clearFeedback();
+			} finally {
+				for (ValueSource vs : valueSources) {
+					getInterpolator().removeValuesSource(vs);
+				}
+
+				for (InterpolationPostProcessor postProcessor : postProcessors) {
+					getInterpolator().removePostProcessor(postProcessor);
+				}
+			}
+		}
+
+		return result;
+	}
+
+	protected Interpolator createInterpolator() {
+		CiInterpolatorImpl interpolator = new CiInterpolatorImpl();
+		interpolator.setCacheAnswers(true);
+
+		return interpolator;
+	}
+
+	private static final class InterpolateObjectAction implements PrivilegedAction<Object> {
+
+		private final LinkedList<Object> interpolationTargets;
+
+		private final CiModelInterpolator modelInterpolator;
+
+		private final List<? extends ValueSource> valueSources;
+
+		private final List<? extends InterpolationPostProcessor> postProcessors;
+
+		private final ModelProblemCollector problems;
+
+		public InterpolateObjectAction(Object target, List<? extends ValueSource> valueSources,
+				List<? extends InterpolationPostProcessor> postProcessors, CiModelInterpolator modelInterpolator,
+				ModelProblemCollector problems) {
+			this.valueSources = valueSources;
+			this.postProcessors = postProcessors;
+
+			this.interpolationTargets = new LinkedList<Object>();
+			interpolationTargets.add(target);
+
+			this.modelInterpolator = modelInterpolator;
+
+			this.problems = problems;
+		}
+
+		public Object run() {
+			while (!interpolationTargets.isEmpty()) {
+				Object obj = interpolationTargets.removeFirst();
+
+				traverseObjectWithParents(obj.getClass(), obj);
+			}
+
+			return null;
+		}
+
+		private String interpolate(String value) {
+			return modelInterpolator.interpolateInternal(value, valueSources, postProcessors, problems);
+		}
+
+		private void traverseObjectWithParents(Class<?> cls, Object target) {
+			if (cls == null) {
+				return;
+			}
+
+			CacheItem cacheEntry = getCacheEntry(cls);
+			if (cacheEntry.isArray()) {
+				evaluateArray(target, this);
+			} else if (cacheEntry.isQualifiedForInterpolation) {
+				cacheEntry.interpolate(target, this);
+
+				traverseObjectWithParents(cls.getSuperclass(), target);
+			}
+		}
+
+		private CacheItem getCacheEntry(Class<?> cls) {
+			CacheItem cacheItem = CACHED_ENTRIES.get(cls);
+			if (cacheItem == null) {
+				cacheItem = new CacheItem(cls);
+				CACHED_ENTRIES.put(cls, cacheItem);
+			}
+			return cacheItem;
+		}
+
+		private static void evaluateArray(Object target, InterpolateObjectAction ctx) {
+			int len = Array.getLength(target);
+			for (int i = 0; i < len; i++) {
+				Object value = Array.get(target, i);
+				if (value != null) {
+					if (String.class == value.getClass()) {
+						String interpolated = ctx.interpolate((String) value);
+
+						if (!interpolated.equals(value)) {
+							Array.set(target, i, interpolated);
+						}
+					} else {
+						ctx.interpolationTargets.add(value);
+					}
+				}
+			}
+		}
+
+		private static class CacheItem {
+			private final boolean isArray;
+
+			private final boolean isQualifiedForInterpolation;
+
+			private final CacheField[] fields;
+
+			private boolean isQualifiedForInterpolation(Class<?> cls) {
+				return !cls.getName().startsWith("java");
+			}
+
+			private boolean isQualifiedForInterpolation(Field field, Class<?> fieldType) {
+				if (Map.class.equals(fieldType) && "locations".equals(field.getName())) {
+					return false;
+				}
+
+				// noinspection SimplifiableIfStatement
+				if (fieldType.isPrimitive()) {
+					return false;
+				}
+
+				return !"parent".equals(field.getName());
+			}
+
+			CacheItem(Class clazz) {
+				this.isQualifiedForInterpolation = isQualifiedForInterpolation(clazz);
+				this.isArray = clazz.isArray();
+				List<CacheField> fields = new ArrayList<CacheField>();
+				for (Field currentField : clazz.getDeclaredFields()) {
+					Class<?> type = currentField.getType();
+					if (isQualifiedForInterpolation(currentField, type)) {
+						if (String.class == type) {
+							if (!Modifier.isFinal(currentField.getModifiers())) {
+								fields.add(new StringField(currentField));
+							}
+						} else if (List.class.isAssignableFrom(type)) {
+							fields.add(new ListField(currentField));
+						} else if (Collection.class.isAssignableFrom(type)) {
+							throw new RuntimeException("We dont interpolate into collections, use a list instead");
+						} else if (Map.class.isAssignableFrom(type)) {
+							fields.add(new MapField(currentField));
+						} else {
+							fields.add(new ObjectField(currentField));
+						}
+					}
+
+				}
+				this.fields = fields.toArray(new CacheField[fields.size()]);
+
+			}
+
+			public void interpolate(Object target, InterpolateObjectAction interpolateObjectAction) {
+				for (CacheField field : fields) {
+					field.interpolate(target, interpolateObjectAction);
+				}
+			}
+
+			public boolean isArray() {
+				return isArray;
+			}
+		}
+
+		abstract static class CacheField {
+			protected final Field field;
+
+			CacheField(Field field) {
+				this.field = field;
+			}
+
+			void interpolate(Object target, InterpolateObjectAction interpolateObjectAction) {
+				synchronized (field) {
+					boolean isAccessible = field.isAccessible();
+					field.setAccessible(true);
+					try {
+						doInterpolate(target, interpolateObjectAction);
+					} catch (IllegalArgumentException e) {
+						interpolateObjectAction.problems
+								.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE)
+										.setMessage("Failed to interpolate field3: " + field + " on class: "
+												+ field.getType().getName())
+										.setException(e)); // todo: Not entirely
+															// the same message
+					} catch (IllegalAccessException e) {
+						interpolateObjectAction.problems
+								.add(new ModelProblemCollectorRequest(Severity.ERROR, Version.BASE)
+										.setMessage("Failed to interpolate field4: " + field + " on class: "
+												+ field.getType().getName())
+										.setException(e));
+					} finally {
+						field.setAccessible(isAccessible);
+					}
+				}
+
+			}
+
+			abstract void doInterpolate(Object target, InterpolateObjectAction ctx) throws IllegalAccessException;
+		}
+
+		static final class StringField extends CacheField {
+			StringField(Field field) {
+				super(field);
+			}
+
+			@Override
+			void doInterpolate(Object target, InterpolateObjectAction ctx) throws IllegalAccessException {
+				String value = (String) field.get(target);
+				if (value == null) {
+					return;
+				}
+
+				String interpolated = ctx.interpolate(value);
+
+				if (!interpolated.equals(value)) {
+					field.set(target, interpolated);
+				}
+			}
+		}
+
+		static final class ListField extends CacheField {
+			ListField(Field field) {
+				super(field);
+			}
+
+			@Override
+			void doInterpolate(Object target, InterpolateObjectAction ctx) throws IllegalAccessException {
+				@SuppressWarnings("unchecked")
+				List<Object> c = (List<Object>) field.get(target);
+				if (c == null) {
+					return;
+				}
+
+				int size = c.size();
+				Object value;
+				for (int i = 0; i < size; i++) {
+
+					value = c.get(i);
+
+					if (value != null) {
+						if (String.class == value.getClass()) {
+							String interpolated = ctx.interpolate((String) value);
+
+							if (!interpolated.equals(value)) {
+								try {
+									c.set(i, interpolated);
+								} catch (UnsupportedOperationException e) {
+									return;
+								}
+							}
+						} else {
+							if (value.getClass().isArray()) {
+								evaluateArray(value, ctx);
+							} else {
+								ctx.interpolationTargets.add(value);
+							}
+						}
+					}
+				}
+			}
+		}
+
+		static final class MapField extends CacheField {
+			MapField(Field field) {
+				super(field);
+			}
+
+			@Override
+			void doInterpolate(Object target, InterpolateObjectAction ctx) throws IllegalAccessException {
+				@SuppressWarnings("unchecked")
+				Map<Object, Object> m = (Map<Object, Object>) field.get(target);
+				if (m == null || m.isEmpty()) {
+					return;
+				}
+
+				for (Map.Entry<Object, Object> entry : m.entrySet()) {
+					Object value = entry.getValue();
+
+					if (value == null) {
+						continue;
+					}
+
+					if (String.class == value.getClass()) {
+						String interpolated = ctx.interpolate((String) value);
+
+						if (!interpolated.equals(value)) {
+							try {
+								entry.setValue(interpolated);
+							} catch (UnsupportedOperationException ignore) {
+								// nop
+							}
+						}
+					} else if (value.getClass().isArray()) {
+						evaluateArray(value, ctx);
+					} else {
+						ctx.interpolationTargets.add(value);
+					}
+				}
+			}
+		}
+
+		static final class ObjectField extends CacheField {
+			private final boolean isArray;
+
+			ObjectField(Field field) {
+				super(field);
+				this.isArray = field.getType().isArray();
+			}
+
+			@Override
+			void doInterpolate(Object target, InterpolateObjectAction ctx) throws IllegalAccessException {
+				Object value = field.get(target);
+				if (value != null) {
+					if (isArray) {
+						evaluateArray(value, ctx);
+					} else {
+						ctx.interpolationTargets.add(value);
+					}
+				}
+			}
+		}
+
+	}
+
+	protected List<ValueSource> createValueSources(final Model model, final File projectDir,
+			final ModelBuildingRequest config, final ModelProblemCollector problems) {
+		Properties modelProperties = model.getProperties();
+
+		ValueSource modelValueSource1 = new PrefixedObjectValueSource(PROJECT_PREFIXES, model, false);
+		if (config.getValidationLevel() >= ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_2_0) {
+			modelValueSource1 = new ProblemDetectingValueSource(modelValueSource1, "pom.", "project.", problems);
+		}
+
+		ValueSource modelValueSource2 = new ObjectBasedValueSource(model);
+		if (config.getValidationLevel() >= ModelBuildingRequest.VALIDATION_LEVEL_MAVEN_2_0) {
+			modelValueSource2 = new ProblemDetectingValueSource(modelValueSource2, "", "project.", problems);
+		}
+
+		// NOTE: Order counts here!
+		List<ValueSource> valueSources = new ArrayList<ValueSource>(9);
+
+		if (projectDir != null) {
+			ValueSource basedirValueSource = new PrefixedValueSourceWrapper(new AbstractValueSource(false) {
+				public Object getValue(String expression) {
+					if ("basedir".equals(expression)) {
+						return projectDir.getAbsolutePath();
+					}
+					return null;
+				}
+			}, PROJECT_PREFIXES, true);
+			valueSources.add(basedirValueSource);
+
+			ValueSource baseUriValueSource = new PrefixedValueSourceWrapper(new AbstractValueSource(false) {
+				public Object getValue(String expression) {
+					if ("baseUri".equals(expression)) {
+						return projectDir.getAbsoluteFile().toURI().toString();
+					}
+					return null;
+				}
+			}, PROJECT_PREFIXES, false);
+			valueSources.add(baseUriValueSource);
+			valueSources.add(new BuildTimestampValueSource(config.getBuildStartTime(), modelProperties));
+		}
+
+		valueSources.add(modelValueSource1);
+
+		valueSources.add(new MapBasedValueSource(config.getUserProperties()));
+
+		valueSources.add(new MapBasedValueSource(modelProperties));
+
+		valueSources.add(new MapBasedValueSource(config.getSystemProperties()));
+
+		valueSources.add(new AbstractValueSource(false) {
+			public Object getValue(String expression) {
+				return config.getSystemProperties().getProperty("env." + expression);
+			}
+		});
+
+		valueSources.add(modelValueSource2);
+
+		return valueSources;
+	}
+
+	protected List<? extends InterpolationPostProcessor> createPostProcessors(final Model model, final File projectDir,
+			final ModelBuildingRequest config) {
+		List<InterpolationPostProcessor> processors = new ArrayList<InterpolationPostProcessor>(2);
+		if (projectDir != null) {
+			processors.add(new PathTranslatingPostProcessor(PROJECT_PREFIXES, TRANSLATED_PATH_EXPRESSIONS, projectDir,
+					pathTranslator));
+		}
+		processors.add(new UrlNormalizingPostProcessor(urlNormalizer));
+		return processors;
+	}
+
+	protected RecursionInterceptor getRecursionInterceptor() {
+		return recursionInterceptor;
+	}
+
+	protected void setRecursionInterceptor(RecursionInterceptor recursionInterceptor) {
+		this.recursionInterceptor = recursionInterceptor;
+	}
+
+	protected final Interpolator getInterpolator() {
+		return interpolator;
+	}
+
+	class BuildTimestampValueSource extends AbstractValueSource {
+		private final MavenBuildTimestamp mavenBuildTimestamp;
+
+		public BuildTimestampValueSource(Date startTime, Properties properties) {
+			super(false);
+			this.mavenBuildTimestamp = new MavenBuildTimestamp(startTime, properties);
+		}
+
+		public Object getValue(String expression) {
+			if ("build.timestamp".equals(expression) || "maven.build.timestamp".equals(expression)) {
+				return mavenBuildTimestamp.formattedTimestamp();
+			}
+			return null;
+		}
+	}
+
+	class ProblemDetectingValueSource implements ValueSource {
+
+		private final ValueSource valueSource;
+
+		private final String bannedPrefix;
+
+		private final String newPrefix;
+
+		private final ModelProblemCollector problems;
+
+		public ProblemDetectingValueSource(ValueSource valueSource, String bannedPrefix, String newPrefix,
+				ModelProblemCollector problems) {
+			this.valueSource = valueSource;
+			this.bannedPrefix = bannedPrefix;
+			this.newPrefix = newPrefix;
+			this.problems = problems;
+		}
+
+		public Object getValue(String expression) {
+			Object value = valueSource.getValue(expression);
+
+			if (value != null && expression.startsWith(bannedPrefix)) {
+				String msg = "The expression ${" + expression + "} is deprecated.";
+				if (newPrefix != null && newPrefix.length() > 0) {
+					msg += " Please use ${" + newPrefix + expression.substring(bannedPrefix.length()) + "} instead.";
+				}
+				problems.add(new ModelProblemCollectorRequest(Severity.WARNING, Version.V20).setMessage(msg));
+			}
+
+			return value;
+		}
+
+		@SuppressWarnings("unchecked")
+		public List getFeedback() {
+			return valueSource.getFeedback();
+		}
+
+		public void clearFeedback() {
+			valueSource.clearFeedback();
+		}
+
+	}
+
+	class PathTranslatingPostProcessor implements InterpolationPostProcessor {
+
+		private final Collection<String> unprefixedPathKeys;
+		private final File projectDir;
+		private final PathTranslator pathTranslator;
+		private final List<String> expressionPrefixes;
+
+		public PathTranslatingPostProcessor(List<String> expressionPrefixes, Collection<String> unprefixedPathKeys,
+				File projectDir, PathTranslator pathTranslator) {
+			this.expressionPrefixes = expressionPrefixes;
+			this.unprefixedPathKeys = unprefixedPathKeys;
+			this.projectDir = projectDir;
+			this.pathTranslator = pathTranslator;
+		}
+
+		public Object execute(String expression, Object value) {
+			if (value != null) {
+				expression = ValueSourceUtils.trimPrefix(expression, expressionPrefixes, true);
+
+				if (unprefixedPathKeys.contains(expression)) {
+					return pathTranslator.alignToBaseDirectory(String.valueOf(value), projectDir);
+				}
+			}
+
+			return null;
+		}
+
+	}
+
+	class UrlNormalizingPostProcessor implements InterpolationPostProcessor {
+
+
+		private UrlNormalizer normalizer;
+
+		public UrlNormalizingPostProcessor(UrlNormalizer normalizer) {
+			this.normalizer = normalizer;
+		}
+
+		public Object execute(String expression, Object value) {
+			Set<String> expressions = new HashSet<String>();
+			expressions.add("project.url");
+			expressions.add("project.scm.url");
+			expressions.add("project.scm.connection");
+			expressions.add("project.scm.developerConnection");
+			expressions.add("project.distributionManagement.site.url");
+
+			if (value != null && expressions.contains(expression)) {
+				return normalizer.normalize(value.toString());
+			}
+
+			return null;
+		}
+
+	}
+
+}

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component-set>
+  <components>
+    <component>
+      <role>org.codehaus.mojo.flatten.cifriendly.CiInterpolator</role>
+      <role-hint>default</role-hint>
+      <implementation>org.codehaus.mojo.flatten.cifriendly.CiModelInterpolator</implementation>
+      <description />
+      <isolated-realm>false</isolated-realm>
+    </component>
+  </components>
+</component-set>

--- a/src/test/java/org/codehaus/mojo/flatten/CreateEffectivePomTest.java
+++ b/src/test/java/org/codehaus/mojo/flatten/CreateEffectivePomTest.java
@@ -86,7 +86,7 @@ public class CreateEffectivePomTest
                 depencencyResolver, projectBuildingRequest, Collections.<MavenProject>emptyList() );
         ModelBuildingRequest buildingRequest =
             new DefaultModelBuildingRequest().setPomFile( pomFile ).setModelResolver( resolver ).setUserProperties( userProperties );
-        Model effectivePom = FlattenMojo.createEffectivePom( buildingRequest, false );
+        Model effectivePom = FlattenMojo.createEffectivePom( buildingRequest, false, FlattenMode.defaults );
         assertThat( effectivePom.getName() ).isEqualTo( magicValue );
     }
 


### PR DESCRIPTION
Here is one possible implementation of CI friendly variable resolver.

This has some things I don't personally like. For example CiInterpolatorImpl just basically replicates StringSearchInterpolator because first I tried to extend it and overwrite just some of the methods but that lead to weird classloading issues that I didn't have the energy to solve.

Also resolving variables inside profile dependencies doesn't work as it should but that is because of the multiple other problems in profile resolving in the flatten plugin.

Now I have found out that there might be some better solutions to flattening CI variables in poms. Like https://github.com/fmarot/cifriendly-maven-plugin which seems to be a much simpler approach to solving just this one problem. I haven't tried that plugin though.

Anyway, I just wanted to leave this so that other people can access this particular solution if it is what they need in their projects.