### PR TITLE
Use injection in FlattenMojo to work with jgitver

### DIFF
--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -74,6 +74,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
+import org.apache.maven.model.building.ModelBuilder;
+import org.codehaus.plexus.component.annotations.Requirement;
 
 /**
  * This MOJO realizes the goal <code>flatten</code> that generates the flattened POM and {@link #isUpdatePomFile()
@@ -310,6 +312,9 @@ public class FlattenMojo
     @Component
     private DependencyResolver dependencyResolver;
 
+    @Component(role = ModelBuilder.class)
+    private DefaultModelBuilder defaultModelBuilder;
+    
     /**
      * The constructor.
      */
@@ -722,7 +727,7 @@ public class FlattenMojo
      * @return the parsed and calculated effective POM.
      * @throws MojoExecutionException if anything goes wrong.
      */
-    protected static Model createEffectivePom( ModelBuildingRequest buildingRequest,
+    protected Model createEffectivePom( ModelBuildingRequest buildingRequest,
                                                final boolean embedBuildProfileDependencies, final FlattenMode flattenMode )
         throws MojoExecutionException
     {
@@ -764,7 +769,7 @@ public class FlattenMojo
                     return activeProfiles;
                 }
             };
-            DefaultModelBuilder defaultModelBuilder = new DefaultModelBuilderFactory().newInstance();
+            
             defaultModelBuilder.setProfileInjector( profileInjector ).setProfileSelector( profileSelector );
             //if (flattenMode == FlattenMode.resolveCiFriendliesOnly) {
             //	defaultModelBuilder.setModelInterpolator(new CiModelInterpolator());

--- a/src/test/java/org/codehaus/mojo/flatten/CreateEffectivePomTest.java
+++ b/src/test/java/org/codehaus/mojo/flatten/CreateEffectivePomTest.java
@@ -48,6 +48,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import org.apache.maven.model.building.DefaultModelBuilderFactory;
 
 /**
  * Test-Case for {@link FlattenMojo}.
@@ -58,6 +59,8 @@ public class CreateEffectivePomTest
     extends Assertions
 {
 
+    FlattenMojo tested = new FlattenMojo();
+    
     /**
      * Tests method to create effective POM.
      *
@@ -86,7 +89,8 @@ public class CreateEffectivePomTest
                 depencencyResolver, projectBuildingRequest, Collections.<MavenProject>emptyList() );
         ModelBuildingRequest buildingRequest =
             new DefaultModelBuildingRequest().setPomFile( pomFile ).setModelResolver( resolver ).setUserProperties( userProperties );
-        Model effectivePom = FlattenMojo.createEffectivePom( buildingRequest, false, FlattenMode.defaults );
+        setDeclaredField(tested, "defaultModelBuilder", new DefaultModelBuilderFactory().newInstance());
+        Model effectivePom = tested.createEffectivePom( buildingRequest, false, FlattenMode.defaults );
         assertThat( effectivePom.getName() ).isEqualTo( magicValue );
     }
 


### PR DESCRIPTION
When working with [jgitver](https://github.com/jgitver/jgitver-maven-plugin) I hit a problem where processed versions produced by the extension were not getting picked up during flatten execution. I tracked this bug (?) down to `FlattenMojo` where `ModelBuilder` instance is obtained using `new`, thus the custom impl of this interface provided by jgitver is not picked up and versions are not processed. 

This PR proposes to inject `ModelBuilder` into the MOJO so custom implementations provided by extensions in general (and jgitver in our particular case) have a chance to get picked up.

I do not have a reproducer case at the moment, but the proposed change fixes the problem for us and does not seem to break any existing behavior.

cc @McFoggy