### PR TITLE
Flatten maven plugin 1.1.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,10 @@
   <artifactId>flatten-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
   <name>Maven Flatten Plugin</name>
-  <version>1.1.0</version>
+  <!-- Custom patch to org.codehaus.mojo:flatten-maven-plugin:1.1.0
+       For more details please see "git diff flatten-maven-plugin-1.1.0 flatten-maven-plugin-1.1.x"
+       or visit https://github.com/nruzic/flatten-maven-plugin -->
+  <version>1.1.0.1</version>
   <description>Plugin to generate flattened POM (reduced and resolved information required for consumers of maven repositories) and to use (install, sign, deploy) it instead of original pom.xml.</description>
   <inceptionYear>2014</inceptionYear>
   <prerequisites>

--- a/src/it/projects/complete-multimodule-parent-pom-cifriendly/pom.xml
+++ b/src/it/projects/complete-multimodule-parent-pom-cifriendly/pom.xml
@@ -16,6 +16,8 @@
 				<artifactId>flatten-maven-plugin</artifactId>
 				<configuration>
 					<flattenMode>resolveCiFriendliesOnly</flattenMode>
+                    <!-- Use this instead to fix interpolation bug
+                    <flattenMode>version</flattenMode>-->
 				</configuration>
 			</plugin>
 		</plugins>
@@ -100,6 +102,8 @@
 		<revision>1.2.3.0</revision>
 
 		<key>value</key>
+        <repoHost>foo</repoHost>
+        <repoPath>bar</repoPath>
 	</properties>
 
 	<reporting>
@@ -114,4 +118,19 @@
 
 	<url>http://mojo.codehaus.org</url>
 
+    <profiles>
+        <profile>
+            <id>cifriendly-profile-bug</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>myrepo</id>
+                    <name>myrepo</name>
+                    <url>https://${repoHost}/${repoPath}</url>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
 </project>

--- a/src/it/projects/complete-multimodule-parent-pom-cifriendly/verify.groovy
+++ b/src/it/projects/complete-multimodule-parent-pom-cifriendly/verify.groovy
@@ -82,3 +82,6 @@ assert 'org.codehaus.mojo.flatten.its' == flattendChildWithParentProject.groupId
 assert 'multimodule-module-with-parent-cifriendly' == flattendChildWithParentProject.artifactId.text()
 assert '1.2.3.4' == flattendChildWithParentProject.version.text()
 assert '1.2.3.4' == flattendChildWithParentProject.parent.version.text()
+
+// CiFriendly interpolation bug
+assert 'https://${repoHost}/${repoPath}' == flattendProject.profiles.profile[0].repositories.repository[0].url.text()

--- a/src/main/java/org/codehaus/mojo/flatten/ElementHandling.java
+++ b/src/main/java/org/codehaus/mojo/flatten/ElementHandling.java
@@ -47,6 +47,9 @@ public enum ElementHandling
     keep,
 
     /** Remove the element entirely so it will not be present in flattened POM. */
-    remove
+    remove,
+
+    /** Take the element untouched from the original POM. Fix for {@link #keep} */
+    keepRaw
 
 }

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenDescriptor.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenDescriptor.java
@@ -317,6 +317,22 @@ public class FlattenDescriptor
     }
 
     /**
+     * @return {@link ElementHandling} for {@link Model#getLicenses() licenses}.
+     */
+    public ElementHandling getLicenses()
+    {
+        return getHandling( PomProperty.LICENSES );
+    }
+
+    /**
+     * @param licenses the {@link #getLicenses() licenses} to set.
+     */
+    public void setLicenses( ElementHandling licenses )
+    {
+        setHandling( PomProperty.LICENSES, licenses );
+    }
+
+    /**
      * @return {@link ElementHandling} for {@link Model#getCiManagement() ciManagement}.
      */
     public ElementHandling getCiManagement()

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMode.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMode.java
@@ -77,8 +77,12 @@ public enum FlattenMode
     /** Only resolves variables revision, sha1 and changelist. Keeps everything else. 
      * See <a href="https://maven.apache.org/maven-ci-friendly.html">Maven CI Friendly</a> for further details. 
      */
-    resolveCiFriendliesOnly;
+    resolveCiFriendliesOnly,
 
+    /**
+     * Fix for {@link #resolveCiFriendliesOnly}
+     */
+    version;
 
     /**
      * @return the {@link FlattenDescriptor} defined by this {@link FlattenMode}.
@@ -146,6 +150,34 @@ public enum FlattenMode
                 descriptor.setScm( ElementHandling.interpolate );
                 descriptor.setUrl( ElementHandling.interpolate );
                 descriptor.setVersion( ElementHandling.resolve );
+                break;
+            case version:
+                descriptor.setBuild(ElementHandling.keepRaw);
+                descriptor.setCiManagement(ElementHandling.keepRaw);
+                descriptor.setContributors(ElementHandling.keepRaw);
+                descriptor.setDependencies(ElementHandling.keepRaw);
+                descriptor.setDependencyManagement(ElementHandling.keepRaw);
+                descriptor.setDescription(ElementHandling.keepRaw);
+                descriptor.setDevelopers(ElementHandling.keepRaw);
+                descriptor.setDistributionManagement(ElementHandling.keepRaw);
+                descriptor.setInceptionYear(ElementHandling.keepRaw);
+                descriptor.setIssueManagement(ElementHandling.keepRaw);
+                descriptor.setLicenses(ElementHandling.keepRaw);
+                descriptor.setMailingLists(ElementHandling.keepRaw);
+                descriptor.setModules(ElementHandling.keepRaw);
+                descriptor.setName(ElementHandling.keepRaw);
+                descriptor.setOrganization(ElementHandling.keepRaw);
+                descriptor.setParent(ElementHandling.resolve);
+                descriptor.setPluginManagement(ElementHandling.keepRaw);
+                descriptor.setPluginRepositories(ElementHandling.keepRaw);
+                descriptor.setPrerequisites(ElementHandling.keepRaw);
+                descriptor.setProfiles(ElementHandling.keepRaw);
+                descriptor.setProperties(ElementHandling.keepRaw);
+                descriptor.setReporting(ElementHandling.keepRaw);
+                descriptor.setRepositories(ElementHandling.keepRaw);
+                descriptor.setScm(ElementHandling.keepRaw);
+                descriptor.setUrl(ElementHandling.keepRaw);
+                descriptor.setVersion(ElementHandling.resolve);
                 break;
             case clean:
                 // nothing to do...


### PR DESCRIPTION
resolveCiFriendliesOnly mode is not perfect currently.
It should interpolate version and parent elements only.
I have discovered that if you have some profiles active during build, flatten-maven-plugin in resolveCiFriendliesOnly mode will interpolate some placeholders in active profiles (e.g. if you use mvn clean install -PsomeProfile).
This is not desirable, at least for me :-)
I have introduced alternative solution for resolving original pom model in FlattenMojo so that no placeholders are resolved except version and parent.
Solution is not perfect, but it can be used as guide for more permanent solution to the problem.
Test case is included which illustrates the problem.