### PR TITLE
Fix Javadocs

### DIFF
--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -618,6 +618,7 @@ public class FlattenMojo
      *
      * @param effectivePom is the effective POM.
      * @return the clean POM.
+     * @throws MojoExecutionException if anything goes wrong.
      */
     protected Model createCleanPom( Model effectivePom ) throws MojoExecutionException
     {
@@ -825,6 +826,7 @@ public class FlattenMojo
      *
      * @param buildingRequest {@link ModelBuildingRequest}
      * @param embedBuildProfileDependencies embed build profiles yes/no.
+     * @param flattenMode the flattening mode
      * @return the parsed and calculated effective POM.
      * @throws MojoExecutionException if anything goes wrong.
      */
@@ -957,6 +959,7 @@ public class FlattenMojo
      *
      * @param effectiveModel is the effective POM {@link Model} to process.
      * @return the {@link List} of {@link Dependency dependencies}.
+     * @throws MojoExecutionException if anything goes wrong.
      */
     protected List<Dependency> createFlattenedDependencies( Model effectiveModel )
             throws MojoExecutionException {
@@ -1111,6 +1114,7 @@ public class FlattenMojo
      *
      * @param effectiveModel is the effective POM {@link Model} to process.
      * @param flattenedDependencies is the {@link List} where to add the collected {@link Dependency dependencies}.
+     * @throws MojoExecutionException if anything goes wrong.
      */
     protected void createFlattenedDependencies( Model effectiveModel, List<Dependency> flattenedDependencies )
             throws MojoExecutionException

--- a/src/main/java/org/codehaus/mojo/flatten/cifriendly/CiInterpolatorImpl.java
+++ b/src/main/java/org/codehaus/mojo/flatten/cifriendly/CiInterpolatorImpl.java
@@ -125,8 +125,6 @@ public class CiInterpolatorImpl implements Interpolator {
 	    /**
 	     * Entry point for recursive resolution of an expression and all of its
 	     * nested expressions.
-	     *
-	     * @todo Ensure unresolvable expressions don't trigger infinite recursion.
 	     */
 	    public String interpolate( String input, RecursionInterceptor recursionInterceptor )
 	        throws InterpolationException


### PR DESCRIPTION
The TODO annotation prevents docs pushing, the others only create warnings.
This is needed before the site can be published.