### PR TITLE
#57 Prevent interpolation of a profile activation file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,18 @@
       <version>2.0.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-testing</groupId>
+      <artifactId>maven-plugin-testing-harness</artifactId>
+      <scope>test</scope>
+      <version>3.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-compat</artifactId>
+      <version>${mavenVersion}</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>

--- a/src/it/projects/resolve-properties-ci-do-not-interpolate-profile-activation-file/invoker.properties
+++ b/src/it/projects/resolve-properties-ci-do-not-interpolate-profile-activation-file/invoker.properties
@@ -1,0 +1,1 @@
+invoker.mavenOpts = -Drevision=1.2.3.4 -Dany.property

--- a/src/it/projects/resolve-properties-ci-do-not-interpolate-profile-activation-file/pom.xml
+++ b/src/it/projects/resolve-properties-ci-do-not-interpolate-profile-activation-file/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.codehaus.mojo.flatten.its</groupId>
+	<artifactId>resolve-properties-ci-do-not-interpolate-profile-activation-file</artifactId>
+	<version>${revision}</version>
+
+	<!-- banned -->
+	<build>
+		<defaultGoal>verify</defaultGoal>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<configuration>
+					<flattenMode>resolveCiFriendliesOnly</flattenMode>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<profile>
+			<id>0</id>
+			<activation>
+				<file>
+					<exists>file.txt</exists>
+				</file>
+			</activation>
+		</profile>
+		<profile>
+			<id>1</id>
+			<activation>
+				<file>
+					<exists>${basedir}/file.txt</exists>
+				</file>
+			</activation>
+		</profile>
+		<profile>
+			<id>2</id>
+			<activation>
+				<file>
+					<exists>${any.property}</exists>
+				</file>
+			</activation>
+		</profile>
+		<profile>
+			<id>3</id>
+			<activation>
+				<file>
+					<exists>${revision}</exists>
+				</file>
+			</activation>
+		</profile>
+	</profiles>
+</project>

--- a/src/it/projects/resolve-properties-ci-do-not-interpolate-profile-activation-file/verify.groovy
+++ b/src/it/projects/resolve-properties-ci-do-not-interpolate-profile-activation-file/verify.groovy
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File originalPom = new File( basedir, 'pom.xml' )
+assert originalPom.exists()
+
+def originalProject = new XmlSlurper().parse( originalPom )
+assert 'file.txt' == originalProject.profiles.profile[0].activation.file.exists.text()
+assert '${basedir}/file.txt' == originalProject.profiles.profile[1].activation.file.exists.text()
+assert '${any.property}' == originalProject.profiles.profile[2].activation.file.exists.text()
+assert '${revision}' == originalProject.profiles.profile[3].activation.file.exists.text()
+
+File flattenedPom = new File( basedir, '.flattened-pom.xml' )
+assert flattenedPom.exists()
+def flattenedProject = new XmlSlurper().parse( flattenedPom )
+
+assert 'file.txt' == flattenedProject.profiles.profile[0].activation.file.exists.text()
+assert '${basedir}/file.txt' == flattenedProject.profiles.profile[1].activation.file.exists.text()
+assert '${any.property}' == flattenedProject.profiles.profile[2].activation.file.exists.text()
+assert '1.2.3.4' == flattenedProject.profiles.profile[3].activation.file.exists.text()

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -41,6 +41,7 @@ import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.building.ModelBuildingResult;
 import org.apache.maven.model.building.ModelProblemCollector;
 import org.apache.maven.model.interpolation.ModelInterpolator;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.apache.maven.model.profile.ProfileActivationContext;
 import org.apache.maven.model.profile.ProfileInjector;
@@ -60,9 +61,9 @@ import org.apache.maven.shared.dependency.tree.DependencyTreeBuilderException;
 import org.apache.maven.shared.dependency.tree.traversal.DependencyNodeVisitor;
 import org.codehaus.mojo.flatten.cifriendly.CiInterpolator;
 import org.codehaus.mojo.flatten.model.resolution.FlattenModelResolver;
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.impl.ArtifactDescriptorReader;
 import org.eclipse.aether.resolution.ArtifactDescriptorException;
@@ -569,7 +570,7 @@ public class FlattenMojo
         }
 
         FlattenDescriptor descriptor = getFlattenDescriptor();
-        Model originalPom = this.project.getOriginalModel();
+        Model originalPom = getOriginalModel();
         Model resolvedPom = this.project.getModel();
         Model interpolatedPom = createResolvedPom( buildingRequest );
 
@@ -599,16 +600,25 @@ public class FlattenMojo
         return flattenedPom;
     }
 
-    private Model createResolvedPom( ModelBuildingRequest buildingRequest )
-    {
+    private Model createResolvedPom( ModelBuildingRequest buildingRequest ) throws MojoExecutionException {
         LoggingModelProblemCollector problems = new LoggingModelProblemCollector( getLog() );
-        Model originalModel = this.project.getOriginalModel().clone();
+        Model originalModel = getOriginalModel();
         if (this.flattenMode == FlattenMode.resolveCiFriendliesOnly) {
             return this.modelCiFriendlyInterpolator.interpolateModel( originalModel, this.project.getModel().getProjectDirectory(),
                                                             buildingRequest, problems );
         }
         return this.modelInterpolator.interpolateModel( originalModel, this.project.getModel().getProjectDirectory(),
                                                         buildingRequest, problems );
+    }
+
+    private Model getOriginalModel() throws MojoExecutionException {
+        MavenXpp3Reader reader = new MavenXpp3Reader();
+        try {
+            return reader.read( new FileInputStream( this.project.getFile() ) );
+        }
+        catch ( IOException | XmlPullParserException e ) {
+            throw new MojoExecutionException( "Error reading raw model.", e );
+        }
     }
 
     /**

--- a/src/test/java/org/codehaus/mojo/flatten/FlattenMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/flatten/FlattenMojoTest.java
@@ -1,0 +1,90 @@
+package org.codehaus.mojo.flatten;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.plugin.testing.MojoRule;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test-Case for {@link FlattenMojo}.
+ *
+ * @author dehasi
+ */
+public class FlattenMojoTest {
+
+    private static final String PATH = "src/test/resources/resolve-properties-ci-do-not-interpolate-profile-activation-file/";
+    private static final String POM = PATH + "pom.xml";
+    private static final String FLATTENED_POM = PATH + ".flattened-pom.xml";
+
+    @Rule
+    public MojoRule rule = new MojoRule();
+
+    /**
+     * Test method to check that profile activation file is not interpolated.
+     *
+     * @throws Exception if something goes wrong.
+     */
+    @Test
+    public void keepsProfileActivationFile() throws Exception {
+        MavenProject project = rule.readMavenProject( new File( PATH ) );
+        FlattenMojo flattenMojo = (FlattenMojo) rule.lookupConfiguredMojo( project, "flatten" );
+
+        flattenMojo.execute();
+
+        assertThat( profileActivationFile( FLATTENED_POM ) )
+            .isEqualTo( profileActivationFile( POM ) );
+    }
+
+    private static String profileActivationFile( String pom ) throws Exception  {
+        return readPom( pom ).getProfiles().get( 0 ).getActivation().getFile().getExists();
+    }
+
+    private static Model readPom(String pomFilePath) throws IOException, XmlPullParserException {
+        MavenXpp3Reader reader = new MavenXpp3Reader();
+
+        return reader.read( new FileInputStream( new File( pomFilePath ) ) );
+    }
+
+    /**
+     * After test method. Removes flattened-pom.xml file which is created during test.
+     *
+     * @throws RuntimeException if can't remove file.
+     */
+    @After
+    public void removeFlattenedPom() throws IOException {
+        File flattenedPom = new File( FLATTENED_POM );
+        if ( flattenedPom.exists() ) {
+            if ( !flattenedPom.delete() ) {
+                throw new IOException( "Can't delete %s" +  flattenedPom );
+            }
+        }
+    }
+}

--- a/src/test/resources/resolve-properties-ci-do-not-interpolate-profile-activation-file/pom.xml
+++ b/src/test/resources/resolve-properties-ci-do-not-interpolate-profile-activation-file/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.codehaus.mojo.flatten.its</groupId>
+	<artifactId>resolve-properties-ci-do-not-interpolate-profile-activation-file</artifactId>
+	<version>${revision}</version>
+
+	<properties>
+		<revision>1.2.3.4</revision>
+	</properties>
+
+	<build>
+		<defaultGoal>verify</defaultGoal>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<configuration>
+					<flattenMode>resolveCiFriendliesOnly</flattenMode>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<profile>
+			<activation>
+				<file>
+					<exists>file.txt</exists>
+				</file>
+			</activation>
+		</profile>
+	</profiles>
+</project>


### PR DESCRIPTION
Fixes #57 
Relates #114 
Relates [MNG-6802](https://issues.apache.org/jira/browse/MNG-6802), [MNG-5612](https://issues.apache.org/jira/browse/MNG-5612)

A profile activation file is being interpolated during `flatten-maven-plugin` run.

Example
```xml
<profile>
    <id>dockerfile-update</id>
    <activation>
        <file>
            <exists>Dockerfile</exists> <!-- problem here -->
        </file>
    </activation>
</profile>
```

Result
```xml
<profile>
    <id>dockerfile-update</id>
    <activation>
        <file>
            <exists>aboslute/path/resolved/on/building/machine/Dockerfile</exists>
        </file>
    </activation>
</profile>
```

The root of the problem in [FileProfileActivator.isActive()](https://github.com/apache/maven/blob/master/maven-model-builder/src/main/java/org/apache/maven/model/profile/activation/FileProfileActivator.java#L70)
method.

It is called in [DefaultModelBuilder.build()](https://github.com/apache/maven/blob/master/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java#L310).
Which happens [here](https://github.com/apache/maven/blob/master/maven-model-builder/src/main/java/org/apache/maven/model/profile/activation/FileProfileActivator.java#L154).

That's why `rawModel`  has already interpolated the file path.

It means when `flatten-maven-plugin` calls [this.project.getOriginalModel()](https://github.com/mojohaus/flatten-maven-plugin/blob/master/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java#L572)
it returns already interpolated activation file.

As a solution, we can load a raw model directly from the `pom.xml`.

That's why I introduced method `getOriginalModel()` which loads
`Model` from the proper `pom.xml`.

During troubleshooting, I added a unit-ish test `FlattenMojoTest`
to be able to debug.
That's why I added `maven-plugin-testing-harness` and `maven-compat`
dependencies. I can remove the test if you wish.

@hohwille @rfscholte could you take a look.

If you agree that `FileProfileActivator.isActive()` has a bug because it updates the input parameter `profile`, I'll be happy to fix it.

