### PR TITLE
Fix minor tag problem in flatten goal description

### DIFF
--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -323,7 +323,7 @@ public class FlattenMojo
      * <td><p>Flatten both direct and transitive dependencies. This will examine the full dependency tree, and pull up
      * all transitive dependencies as a direct dependency, and setting their versions appropriately.</p>
      * <p>This is recommended if you are releasing a library that uses dependency management to manage dependency
-     * versions.</p>/td>
+     * versions.</p></td>
      * </tr>
      * </tbody>
      * </table>


### PR DESCRIPTION
This pull request fixes a a malformed tag in the Javadoc of a parameter of the `flatten` goal, which results in the tag showing up in the site.