### PR TITLE
Fixes no-overwrite test failure

### DIFF
--- a/src/it/projects/no-overwrite-3.6.2-before/verify.groovy
+++ b/src/it/projects/no-overwrite-3.6.2-before/verify.groovy
@@ -17,7 +17,8 @@
  * under the License.
  */
 String os = System.getProperty("os.name");
-String mavenVersion = os.contains("Windows") ? "mvnw.cmd -v".execute().text.split()[2] : "./mvnw -v".execute().text.split()[3]
+String[] mavenWords = os.contains("Windows") ? "mvnw.cmd -v".execute().text.split() : "./mvnw -v".execute().text.split()
+String mavenVersion = mavenWords[1] == "Maven" ? mavenWords[2] : mavenWords[3]
 String[] mavenVersionArray = mavenVersion.split("\\.")
 int[] versionArray = new int[3]
 for (int i = 0; i < 3; i++)

--- a/src/it/projects/no-overwrite-3.6.2-before/verify.groovy
+++ b/src/it/projects/no-overwrite-3.6.2-before/verify.groovy
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-String mavenVersion = "./mvnw -v".execute().text.split()[2]
+String mavenVersion = "./mvnw -v".execute().text.split()[3]
 String[] mavenVersionArray = mavenVersion.split("\\.")
 int[] versionArray = new int[3]
 for (int i = 0; i < 3; i++)

--- a/src/it/projects/no-overwrite-3.6.2-before/verify.groovy
+++ b/src/it/projects/no-overwrite-3.6.2-before/verify.groovy
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-String mavenVersion = "./mvnw -v".execute().text.split()[3]
+String os = System.getProperty("os.name");
+String mavenVersion = os.contains("Windows") ? "mvnw.cmd -v".execute().text.split()[2] : "./mvnw -v".execute().text.split()[3]
 String[] mavenVersionArray = mavenVersion.split("\\.")
 int[] versionArray = new int[3]
 for (int i = 0; i < 3; i++)

--- a/src/it/projects/no-overwrite-3.6.3-later/verify.groovy
+++ b/src/it/projects/no-overwrite-3.6.3-later/verify.groovy
@@ -18,7 +18,8 @@
  */
 
 String os = System.getProperty("os.name").split()[0]
-String mavenVersion = os.contains("Windows") ? "mvnw.cmd -v".execute().text.split()[2] : "./mvnw -v".execute().text.split()[3]
+String[] mavenWords = os.contains("Windows") ? "mvnw.cmd -v".execute().text.split() : "./mvnw -v".execute().text.split()
+String mavenVersion = mavenWords[1] == "Maven" ? mavenWords[2] : mavenWords[3]
 String[] mavenVersionArray = mavenVersion.split("\\.")
 int[] versionArray = new int[3]
 for (int i = 0; i < 3; i++)

--- a/src/it/projects/no-overwrite-3.6.3-later/verify.groovy
+++ b/src/it/projects/no-overwrite-3.6.3-later/verify.groovy
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-String mavenVersion = "./mvnw -v".execute().text.split()[2]
+String mavenVersion = "./mvnw -v".execute().text.split()[3]
 String[] mavenVersionArray = mavenVersion.split("\\.")
 int[] versionArray = new int[3]
 for (int i = 0; i < 3; i++)

--- a/src/it/projects/no-overwrite-3.6.3-later/verify.groovy
+++ b/src/it/projects/no-overwrite-3.6.3-later/verify.groovy
@@ -16,7 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-String mavenVersion = "./mvnw -v".execute().text.split()[3]
+
+String os = System.getProperty("os.name").split()[0]
+String mavenVersion = os.contains("Windows") ? "mvnw.cmd -v".execute().text.split()[2] : "./mvnw -v".execute().text.split()[3]
 String[] mavenVersionArray = mavenVersion.split("\\.")
 int[] versionArray = new int[3]
 for (int i = 0; i < 3; i++)

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -501,9 +501,6 @@ public class FlattenMojo
         try
         {
             binaryData = data.getBytes( encoding );
-            boolean a = file.isFile();
-            boolean b = file.canRead();
-            long c = file.length();
             if ( file.isFile() && file.canRead() && file.length() == binaryData.length )
             {
                 try (InputStream inputStream = new FileInputStream( file ))

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -498,7 +498,9 @@ public class FlattenMojo
         try
         {
             binaryData = data.getBytes( encoding );
-
+            boolean a = file.isFile();
+            boolean b = file.canRead();
+            long c = file.length();
             if ( file.isFile() && file.canRead() && file.length() == binaryData.length )
             {
                 try (InputStream inputStream = new FileInputStream( file ))

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -492,7 +492,10 @@ public class FlattenMojo
     protected void writeStringToFile( String data, File file, String encoding )
         throws MojoExecutionException
     {
-
+        if (System.getProperty("os.name").contains("Windows"))
+        {
+            data = data.replaceAll("\n","\r\n");
+        }
         byte[] binaryData;
 
         try


### PR DESCRIPTION
@olamy , @stephaniewang526 

- fix the problem when parsing version by using "./mvnw -v".
- fix the problem that we need to use "mvnw.cmd -v" to parse Maven version in Windows
- fix the problem of checking existing flattened pom resulting from the different line separator in Windows ("\r\n" instead of "\n")


