### PR TITLE
fix: Add lifecycle mapping metadata for M2E (Eclipse)

### DIFF
--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>clean</goal>
+          <goal>flatten</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
Eclipse m2e allows to provide lifecycle mapping metadata as part of the plugin itself. If present, such mapping metadata will be automatically used by m2e, thus eliminating the need for plugin specific project configurator and/or lifecycle mapping metadata in pom.xml.

Fixes #146 