### PR TITLE
Set `project.originalModel` after flattening

### DIFF
--- a/src/it/projects/flatten-shaded-drp/invoker.properties
+++ b/src/it/projects/flatten-shaded-drp/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=package

--- a/src/it/projects/flatten-shaded-drp/pom.xml
+++ b/src/it/projects/flatten-shaded-drp/pom.xml
@@ -1,0 +1,105 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.codehaus.mojo.flatten.its</groupId>
+    <artifactId>flatten-shaded-drp</artifactId>
+    <version>0.0.1${rev}-SNAPSHOT</version>
+
+    <properties>
+        <flatten.its.version>3.2.1</flatten.its.version>
+        <rev></rev>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>16.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-archiver</artifactId>
+            <version>2.5</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <defaultGoal>package</defaultGoal>
+
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>ossrh</flattenMode>
+                    <embedBuildProfileDependencies>true</embedBuildProfileDependencies>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <minimizeJar>true</minimizeJar>
+                    <createDependencyReducedPom>true</createDependencyReducedPom>
+                    <artifactSet>
+                        <includes>
+                            <include>com.google.guava:*</include>
+                        </includes>
+                    </artifactSet>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>shade</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <!-- should be removed -->
+    <profiles>
+        <profile>
+            <id>foo</id>
+            <activation>
+                <property>
+                    <name>willNotBeActive</name>
+                </property>
+            </activation>
+
+            <dependencies>
+                <dependency>
+                    <groupId>org.codehaus.mojo.flatten.its</groupId>
+                    <artifactId>core</artifactId>
+                    <version>${flatten.its.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>no-one</id>
+            <url>@repository.proxy.url@</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+
+</project>

--- a/src/it/projects/flatten-shaded-drp/src/main/java/com/example/Main.java
+++ b/src/it/projects/flatten-shaded-drp/src/main/java/com/example/Main.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import java.util.List;
+import com.google.common.collect.ImmutableList;
+import org.apache.maven.archiver.MavenArchiver;
+
+public class Main {
+    public static void main(String[] args) {
+        List<Object> l = ImmutableList.of();
+        MavenArchiver a = new MavenArchiver();
+    }
+}

--- a/src/it/projects/flatten-shaded-drp/verify.groovy
+++ b/src/it/projects/flatten-shaded-drp/verify.groovy
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File originalPom = new File( basedir, 'pom.xml' )
+assert originalPom.exists()
+
+def originalProject = new XmlSlurper().parse( originalPom )
+assert 1 ==  originalProject.dependencies.size()
+assert 2 ==  originalProject.dependencies.dependency.size()
+
+File flattendPom = new File( basedir, 'dependency-reduced-pom.xml' )
+assert flattendPom.exists()
+
+def flattendProject = new XmlSlurper().parse( flattendPom )
+assert 1 ==  flattendProject.dependencies.size()
+assert 1 ==  flattendProject.dependencies.dependency.size()
+
+def archiver = flattendProject.dependencies.dependency.find {
+    it.groupId == 'org.apache.maven' && it.artifactId == 'maven-archiver'
+}
+assert '2.5' == archiver.version.text()
+assert 'compile' == archiver.scope.text()
+
+assert 0 == flattendProject.build.size()
+assert 0 == flattendProject.profiles.size()
+assert 0 == flattendProject.pluginRepositories.size()

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -422,6 +422,7 @@ public class FlattenMojo
         if ( isUpdatePomFile() )
         {
             this.project.setPomFile( flattenedPomFile );
+            this.project.setOriginalModel( flattenedPom );
         }
     }
 


### PR DESCRIPTION
Based on the discussion in https://github.com/apache/maven-shade-plugin/pull/129#discussion_r843695691 It seems that the flatten plugin should update the `originalModel` property after we flatten the pom.

This issue resolves #100 and is an alternate way to close #279 