### PR TITLE
Fix copypaste errors in ITs projects

### DIFF
--- a/src/it/projects/profile-with-deps-inherit-parent-depMgmt-test/parent/pom.xml
+++ b/src/it/projects/profile-with-deps-inherit-parent-depMgmt-test/parent/pom.xml
@@ -3,13 +3,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.codehaus.mojo.flatten.its</groupId>
-  <artifactId>profile-with-deps-inherit-parent-depMgmt-jdk_parent</artifactId>
+  <artifactId>profile-with-deps-inherit-parent-depMgmt-test_parent</artifactId>
   <version>0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
-
-  <properties>
-    <javax.annotations.version>1.3.2</javax.annotations.version>
-  </properties>
 
   <dependencyManagement>
     <dependencies>

--- a/src/it/projects/profile-with-deps-inherit-parent-depMgmt-test/pom.xml
+++ b/src/it/projects/profile-with-deps-inherit-parent-depMgmt-test/pom.xml
@@ -3,12 +3,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.codehaus.mojo.flatten.its</groupId>
-  <artifactId>profile-with-deps-inherit-parent-depMgmt-jdk</artifactId>
+  <artifactId>profile-with-deps-inherit-parent-depMgmt-test</artifactId>
   <version>0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <parent>
     <groupId>org.codehaus.mojo.flatten.its</groupId>
-    <artifactId>profile-with-deps-inherit-parent-depMgmt-jdk_parent</artifactId>
+    <artifactId>profile-with-deps-inherit-parent-depMgmt-test_parent</artifactId>
     <version>0.1-SNAPSHOT</version>
     <relativePath>parent</relativePath>
   </parent>


### PR DESCRIPTION
Use unique artifactId and remove javax.annotations.version. Both
were copied from profile-with-deps-inherit-parent-depMgmt-jdk when the
profile-with-deps-inherit-parent-depMgmt-test was created and
it was apparently forgotten to adjust them.