### PR TITLE
Removing test-scope dependencies before building dependency tree

### DIFF
--- a/src/it/projects/flatten-dependency-all-both-test-and-transitive/pom.xml
+++ b/src/it/projects/flatten-dependency-all-both-test-and-transitive/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.flatten.its</groupId>
+  <artifactId>flatten-dependency-all-both-test-and-transitive</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <build>
+    <defaultGoal>verify</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <configuration>
+          <flattenMode>oss</flattenMode>
+          <flattenDependencyMode>all</flattenDependencyMode>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.mojo.flatten.its</groupId>
+      <artifactId>core</artifactId>
+      <!-- This artifact depends on dep:3.2.1 with compile scope -->
+      <version>3.2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.mojo.flatten.its</groupId>
+      <artifactId>dep</artifactId>
+      <version>3.2.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/projects/flatten-dependency-all-both-test-and-transitive/verify.groovy
+++ b/src/it/projects/flatten-dependency-all-both-test-and-transitive/verify.groovy
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File originalPom = new File( basedir, 'pom.xml' )
+assert originalPom.exists()
+
+def originalProject = new XmlSlurper().parse( originalPom )
+assert 2 ==  originalProject.dependencies.dependency.size()
+assert "dep" ==  originalProject.dependencies.dependency[1].artifactId.text()
+assert "3.2.1" ==  originalProject.dependencies.dependency[1].version.text()
+assert "test" ==  originalProject.dependencies.dependency[1].scope.text()
+
+File flattenedPom = new File( basedir, '.flattened-pom.xml' )
+assert flattenedPom.exists()
+
+def flattenedProject = new XmlSlurper().parse( flattenedPom )
+
+// core and dep should be there. It's because while the test-scope dep (the
+// direct dependency), core declares dep as compile-scope (default) dependency.
+assert 2 ==  flattenedProject.dependencies.dependency.size()
+
+assert "core" ==  flattenedProject.dependencies.dependency[0].artifactId.text()
+assert "3.2.1" ==  flattenedProject.dependencies.dependency[0].version.text()
+assert "compile" ==  flattenedProject.dependencies.dependency[0].scope.text()
+
+// The flattened pom.xml should declare the dep under core as compile scope.
+// It's ok to ignore the one in the test-scope dependency.
+assert "dep" ==  flattenedProject.dependencies.dependency[1].artifactId.text()
+assert "3.2.1" ==  flattenedProject.dependencies.dependency[1].version.text()
+assert "compile" ==  flattenedProject.dependencies.dependency[1].scope.text()


### PR DESCRIPTION
# Problem

Fixes #185 , in which test-scope dependencies are unexpectedly excluded when 

- a library itself only uses the dependency as test
- but another dependency actually uses the dependency (non-test)

(The issue has a diagram to illustrate the mechanism)

The root cause is that, when building the dependency tree of the project, test-scope dependencies hides the actually-used dependencies with "omitted for duplicate" mark.

# Solution

With this pull request, when building a dependency tree, the plugin removes the direct, test-scope dependencies. This avoids marking the actually-used dependencies as "omitted for duplicate".

This modification is safe because the test-scope dependencies are not visible to library users in any way.






