### PR TITLE
Use `System.lineSeparator()` on all systems

### DIFF
--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -537,9 +537,9 @@ public class FlattenMojo
     protected void writeStringToFile( String data, File file, String encoding )
         throws MojoExecutionException
     {
-        if ( System.getProperty( "os.name" ).contains( "Windows" ) )
+        if ( !"\n".equals( System.lineSeparator() ) )
         {
-            data = data.replace( "\n", "\r\n" );
+            data = data.replace( "\n", System.lineSeparator() );
         }
         byte[] binaryData;
 


### PR DESCRIPTION
The current version of the `flatten-maven-plugin` switches between LF and CRLF line endings based on the system name.

Reproducible builds require normalization of line endings on all systems.  This PR allows to change the generated line endings by passing an appropriate `-Dline.separator=...` option to Maven and therefore allows to use LF line endings also on Windows machines (or CRLF line endings on UNIX machines).