### PR TITLE
Remove old and deprecated items, use Resolver API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,19 +186,14 @@
 
     <!-- other -->
     <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-dependency-tree</artifactId>
-      <version>3.2.1</version>
-    </dependency>
-    <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
       <version>3.5.0</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-artifact-transfer</artifactId>
-      <version>0.13.1</version>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-interpolation</artifactId>
+      <version>1.26</version>
     </dependency>
 
     <!-- testing -->

--- a/src/it/projects/flatten-dependency-all-depmgnt-optional/invoker.properties
+++ b/src/it/projects/flatten-dependency-all-depmgnt-optional/invoker.properties
@@ -1,0 +1,2 @@
+# Test fails on Maven < 3.5.2
+invoker.maven.version = 3.5.2+

--- a/src/main/java/org/codehaus/mojo/flatten/cifriendly/CiInterpolatorImpl.java
+++ b/src/main/java/org/codehaus/mojo/flatten/cifriendly/CiInterpolatorImpl.java
@@ -34,7 +34,7 @@ import org.codehaus.plexus.interpolation.RecursionInterceptor;
 import org.codehaus.plexus.interpolation.SimpleRecursionInterceptor;
 import org.codehaus.plexus.interpolation.ValueSource;
 
-/*
+/**
  * Based on StringSearchInterpolator from plexus-interpolation,
  * see {@link org.codehaus.plexus.interpolation.StringSearchInterpolator}.
  * This interpolates only the Maven CI Friendly variables revision, sha1 and changelist.
@@ -42,11 +42,11 @@ import org.codehaus.plexus.interpolation.ValueSource;
 public class CiInterpolatorImpl implements Interpolator
 {
 
-    private Map existingAnswers = new HashMap();
+    private final Map existingAnswers = new HashMap();
 
-    private List<ValueSource> valueSources = new ArrayList<>();
+    private final List<ValueSource> valueSources = new ArrayList<>();
 
-    private List<InterpolationPostProcessor> postProcessors = new ArrayList<>();
+    private final List<InterpolationPostProcessor> postProcessors = new ArrayList<>();
 
     private boolean cacheAnswers = false;
 
@@ -54,11 +54,9 @@ public class CiInterpolatorImpl implements Interpolator
 
     public static final String DEFAULT_END_EXPR = "}";
 
-    private String startExpr;
+    private final String startExpr;
 
-    private String endExpr;
-
-    private String escapeString;
+    private final String endExpr;
 
     public CiInterpolatorImpl()
     {
@@ -76,6 +74,7 @@ public class CiInterpolatorImpl implements Interpolator
     /**
      * {@inheritDoc}
      */
+    @Override
     public void addValueSource( ValueSource valueSource )
     {
         valueSources.add( valueSource );
@@ -84,6 +83,7 @@ public class CiInterpolatorImpl implements Interpolator
     /**
      * {@inheritDoc}
      */
+    @Override
     public void removeValuesSource( ValueSource valueSource )
     {
         valueSources.remove( valueSource );
@@ -92,6 +92,7 @@ public class CiInterpolatorImpl implements Interpolator
     /**
      * {@inheritDoc}
      */
+    @Override
     public void addPostProcessor( InterpolationPostProcessor postProcessor )
     {
         postProcessors.add( postProcessor );
@@ -100,23 +101,27 @@ public class CiInterpolatorImpl implements Interpolator
     /**
      * {@inheritDoc}
      */
+    @Override
     public void removePostProcessor( InterpolationPostProcessor postProcessor )
     {
         postProcessors.remove( postProcessor );
     }
 
+    @Override
     public String interpolate( String input, String thisPrefixPattern )
         throws InterpolationException
     {
         return interpolate( input, new SimpleRecursionInterceptor() );
     }
 
+    @Override
     public String interpolate( String input, String thisPrefixPattern, RecursionInterceptor recursionInterceptor )
         throws InterpolationException
     {
         return interpolate( input, recursionInterceptor );
     }
 
+    @Override
     public String interpolate( String input )
         throws InterpolationException
     {
@@ -127,6 +132,7 @@ public class CiInterpolatorImpl implements Interpolator
      * Entry point for recursive resolution of an expression and all of its
      * nested expressions.
      */
+    @Override
     public String interpolate( String input, RecursionInterceptor recursionInterceptor )
         throws InterpolationException
     {
@@ -167,21 +173,6 @@ public class CiInterpolatorImpl implements Interpolator
 
             final String wholeExpr = input.substring( startIdx, endIdx + endExpr.length() );
             String realExpr = wholeExpr.substring( startExpr.length(), wholeExpr.length() - endExpr.length() );
-
-            if ( startIdx >= 0 && escapeString != null && escapeString.length() > 0 )
-            {
-                int startEscapeIdx = startIdx == 0 ? 0 : startIdx - escapeString.length();
-                if ( startEscapeIdx >= 0 )
-                {
-                    String escape = input.substring( startEscapeIdx, startIdx );
-                    if ( escape != null && escapeString.equals( escape ) )
-                    {
-                        result.append( wholeExpr );
-                        result.replace( startEscapeIdx, startEscapeIdx + escapeString.length(), "" );
-                        continue;
-                    }
-                }
-            }
 
             boolean resolved = false;
             if ( !unresolvable.contains( wholeExpr ) )
@@ -235,7 +226,7 @@ public class CiInterpolatorImpl implements Interpolator
                     {
                         value = interpolate( String.valueOf( value ), recursionInterceptor, unresolvable );
 
-                        if ( postProcessors != null && !postProcessors.isEmpty() )
+                        if ( !postProcessors.isEmpty() )
                         {
                             for ( InterpolationPostProcessor postProcessor : postProcessors )
                             {
@@ -252,7 +243,7 @@ public class CiInterpolatorImpl implements Interpolator
                         // result = matcher.replaceFirst( stringValue );
                         // but this could result in multiple lookups of stringValue, and replaceAll is not correct
                         // behaviour
-                        result.append( String.valueOf( value ) );
+                        result.append( value );
                         resolved = true;
                     }
                     else
@@ -271,10 +262,7 @@ public class CiInterpolatorImpl implements Interpolator
                 result.append( wholeExpr );
             }
 
-            if ( endIdx > -1 )
-            {
-                endIdx += endExpr.length() - 1;
-            }
+            endIdx += endExpr.length() - 1;
         }
 
         if ( endIdx == -1 && startIdx > -1 )
@@ -298,6 +286,7 @@ public class CiInterpolatorImpl implements Interpolator
      * @return a {@link List} that may be interspersed with {@link String} and
      * {@link Throwable} instances.
      */
+    @Override
     public List getFeedback()
     {
         List<?> messages = new ArrayList();
@@ -316,6 +305,7 @@ public class CiInterpolatorImpl implements Interpolator
     /**
      * Clear the feedback messages from previous interpolate(..) calls.
      */
+    @Override
     public void clearFeedback()
     {
         for ( ValueSource vs : valueSources )
@@ -324,29 +314,22 @@ public class CiInterpolatorImpl implements Interpolator
         }
     }
 
+    @Override
     public boolean isCacheAnswers()
     {
         return cacheAnswers;
     }
 
+    @Override
     public void setCacheAnswers( boolean cacheAnswers )
     {
         this.cacheAnswers = cacheAnswers;
     }
 
+    @Override
     public void clearAnswers()
     {
         existingAnswers.clear();
-    }
-
-    public String getEscapeString()
-    {
-        return escapeString;
-    }
-
-    public void setEscapeString( String escapeString )
-    {
-        this.escapeString = escapeString;
     }
 
 }

--- a/src/main/java/org/codehaus/mojo/flatten/model/resolution/FlattenModelResolver.java
+++ b/src/main/java/org/codehaus/mojo/flatten/model/resolution/FlattenModelResolver.java
@@ -22,12 +22,6 @@ package org.codehaus.mojo.flatten.model.resolution;
 import java.io.File;
 import java.util.List;
 
-import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.factory.ArtifactFactory;
-import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
-import org.apache.maven.artifact.versioning.VersionRange;
-import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Parent;
 import org.apache.maven.model.Repository;
 import org.apache.maven.model.building.FileModelSource;
@@ -35,12 +29,17 @@ import org.apache.maven.model.building.ModelSource;
 import org.apache.maven.model.resolution.ModelResolver;
 import org.apache.maven.model.resolution.UnresolvableModelException;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResult;
-import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolver;
-import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolverException;
-
-import static java.util.Collections.singleton;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.RequestTrace;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
+import org.eclipse.aether.resolution.VersionRangeResult;
 
 /**
  * This is a custom implementation of {@link ModelResolver} to emulate the maven POM resolution in order to build the
@@ -49,51 +48,49 @@ import static java.util.Collections.singleton;
  * @see org.codehaus.mojo.flatten.FlattenMojo
  * @author Robert Scholte
  */
-@SuppressWarnings( "deprecation" )
 public class FlattenModelResolver
     implements ModelResolver
 {
+    private final RepositorySystemSession session;
 
-    /** The local repository for artifact resolution. */
-    private ArtifactRepository localRepository;
+    private final RepositorySystem repositorySystem;
 
-    /** The factory used to create project artifact instances. */
-    private ArtifactFactory artifactFactory;
+    private final RequestTrace trace;
 
-    /** The resolver used to resolve version ranges */
-    private DependencyResolver depencencyResolver;
+    private final String context;
 
-    private ProjectBuildingRequest projectBuildingRequest;
+    private final List<RemoteRepository> repositories;
 
     /** The modules of the project being built. */
-    private ReactorModelPool reactorModelPool;
+    private final ReactorModelPool reactorModelPool;
 
     /**
      * The constructor.
-     * @param localRepository is the local repository.
-     * @param artifactFactory is the factory used to create project artifact instances.
-     * @param dependencyResolver is the resolver to use for resolving version ranges.
-     * @param projectBuildingRequest is the request for resolving version ranges against {@code dependencyResolver}.
-     * @param reactorModels is the list of modules of the project being built.
      */
-    public FlattenModelResolver( ArtifactRepository localRepository, ArtifactFactory artifactFactory,
-                                DependencyResolver dependencyResolver,
-                                ProjectBuildingRequest projectBuildingRequest, List<MavenProject> reactorModels )
+    public FlattenModelResolver( RepositorySystemSession session,
+                                 RepositorySystem repositorySystem,
+                                 RequestTrace trace,
+                                 String context,
+                                 List<RemoteRepository> repositories,
+                                 List<MavenProject> reactorModels )
     {
-        this.localRepository = localRepository;
-        this.artifactFactory = artifactFactory;
-        this.depencencyResolver = dependencyResolver;
-        this.projectBuildingRequest = projectBuildingRequest;
+        this.session = session;
+        this.repositorySystem = repositorySystem;
+        this.trace = trace;
+        this.context = context;
+        this.repositories = repositories;
+
         this.reactorModelPool = new ReactorModelPool();
         reactorModelPool.addProjects( reactorModels );
     }
 
     private FlattenModelResolver( FlattenModelResolver other )
     {
-        this.localRepository = other.localRepository;
-        this.artifactFactory = other.artifactFactory;
-        this.depencencyResolver = other.depencencyResolver;
-        this.projectBuildingRequest = other.projectBuildingRequest;
+        this.session = other.session;
+        this.repositorySystem = other.repositorySystem;
+        this.trace = other.trace;
+        this.context = other.context;
+        this.repositories = other.repositories;
         this.reactorModelPool = other.reactorModelPool;
     }
 
@@ -101,15 +98,26 @@ public class FlattenModelResolver
      * {@inheritDoc}
      */
     public ModelSource resolveModel( String groupId, String artifactId, String version )
+            throws UnresolvableModelException
     {
         File pomFile = reactorModelPool.find( groupId, artifactId, version );
         if ( pomFile == null )
         {
-            Artifact pomArtifact = this.artifactFactory.createProjectArtifact( groupId, artifactId, version );
-            pomArtifact = this.localRepository.find( pomArtifact );
+            Artifact pomArtifact = new DefaultArtifact( groupId, artifactId, "", "pom", version );
+
+            try
+            {
+                ArtifactRequest request = new ArtifactRequest( pomArtifact, repositories, context );
+                request.setTrace( trace );
+                pomArtifact = repositorySystem.resolveArtifact( session, request ).getArtifact();
+            }
+            catch ( ArtifactResolutionException e )
+            {
+                throw new UnresolvableModelException( e.getMessage(), groupId, artifactId, version, e );
+            }
+
             pomFile = pomArtifact.getFile();
         }
-
         return new FileModelSource( pomFile );
     }
 
@@ -139,67 +147,45 @@ public class FlattenModelResolver
     public ModelSource resolveModel( Parent parent )
         throws UnresolvableModelException
     {
+        Artifact artifact = new DefaultArtifact( parent.getGroupId(), parent.getArtifactId(), "", "pom",
+                parent.getVersion() );
 
-        String groupId = parent.getGroupId();
-        String artifactId = parent.getArtifactId();
-        String version = parent.getVersion();
-
-        // resolve version range (if present)
-        if ( isRestrictedVersionRange( version, groupId, artifactId ) )
-        {
-            version = resolveParentVersionRange( groupId, artifactId, version );
-        }
-
-        return resolveModel( groupId, artifactId, version );
-    }
-
-    private static boolean isRestrictedVersionRange( String version, String groupId, String artifactId )
-        throws UnresolvableModelException
-    {
-        try
-        {
-            return VersionRange.createFromVersionSpec( version ).hasRestrictions();
-        }
-        catch ( InvalidVersionSpecificationException e )
-        {
-            throw new UnresolvableModelException( e.getMessage(), groupId, artifactId, version, e );
-        }
-    }
-
-    private String resolveParentVersionRange( String groupId, String artifactId, String version )
-        throws UnresolvableModelException
-    {
-
-        Dependency parentDependency = new Dependency();
-        parentDependency.setGroupId( groupId );
-        parentDependency.setArtifactId( artifactId );
-        parentDependency.setVersion( version );
-        parentDependency.setClassifier( "" );
-        parentDependency.setType( "pom" );
+        VersionRangeRequest versionRangeRequest = new VersionRangeRequest( artifact, repositories, context );
+        versionRangeRequest.setTrace( trace );
 
         try
         {
-            Iterable<ArtifactResult> artifactResults = depencencyResolver.resolveDependencies(
-                projectBuildingRequest, singleton( parentDependency ), null, null );
-            return artifactResults.iterator().next().getArtifact().getVersion();
+            VersionRangeResult versionRangeResult =
+                    repositorySystem.resolveVersionRange( session, versionRangeRequest );
+
+            if ( versionRangeResult.getHighestVersion() == null )
+            {
+                throw new UnresolvableModelException( "No versions matched the requested range '" + parent.getVersion()
+                        + "'", parent.getGroupId(), parent.getArtifactId(),
+                        parent.getVersion() );
+
+            }
+
+            if ( versionRangeResult.getVersionConstraint() != null
+                    && versionRangeResult.getVersionConstraint().getRange() != null
+                    && versionRangeResult.getVersionConstraint().getRange().getUpperBound() == null )
+            {
+                throw new UnresolvableModelException( "The requested version range '" + parent.getVersion()
+                        + "' does not specify an upper bound", parent.getGroupId(),
+                        parent.getArtifactId(), parent.getVersion() );
+
+            }
+
+            parent.setVersion( versionRangeResult.getHighestVersion().toString() );
         }
-        catch ( DependencyResolverException e )
+        catch ( VersionRangeResolutionException e )
         {
-            throw new UnresolvableModelException( e.getMessage(), groupId, artifactId, version, e );
+            throw new UnresolvableModelException( e.getMessage(), parent.getGroupId(), parent.getArtifactId(),
+                    parent.getVersion(), e );
+
         }
-    }
 
-    public ModelSource resolveModel( Dependency dependency ) throws UnresolvableModelException
-    {
-        return resolveModel( dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion() );
-    }
-
-    /**
-     * @since Apache-Maven-3.2.2 (MNG-5639)
-     */
-    public void resetRepositories()
-    {
-        // ignoring... artifact resolution via repository should already have happened before by maven core.
+        return resolveModel( parent.getGroupId(), parent.getArtifactId(), parent.getVersion() );
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/flatten/model/resolution/ReactorModelPool.java
+++ b/src/main/java/org/codehaus/mojo/flatten/model/resolution/ReactorModelPool.java
@@ -35,7 +35,7 @@ import org.apache.maven.project.MavenProject;
 class ReactorModelPool
 {
 
-    private Map<Coordinates, File> models = new HashMap<>();
+    private final Map<Coordinates, File> models = new HashMap<>();
 
     public File find( String groupId, String artifactId, String version )
     {

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -7,6 +7,16 @@
       <implementation>org.codehaus.mojo.flatten.cifriendly.CiModelInterpolator</implementation>
       <description />
       <isolated-realm>false</isolated-realm>
+      <requirements>
+        <requirement>
+          <role>org.apache.maven.model.path.PathTranslator</role>
+          <fieldName>pathTranslator</fieldName>
+        </requirement>
+        <requirement>
+          <role>org.apache.maven.model.path.UrlNormalizer</role>
+          <fieldName>urlNormalizer</fieldName>
+        </requirement>
+      </requirements>
     </component>
   </components>
 </component-set>

--- a/src/test/java/org/apache/maven/shared/transfer/dependencies/resolve/internal/DefaultTestDependencyResolver.java
+++ b/src/test/java/org/apache/maven/shared/transfer/dependencies/resolve/internal/DefaultTestDependencyResolver.java
@@ -1,5 +1,0 @@
-package org.apache.maven.shared.transfer.dependencies.resolve.internal;
-
-public class DefaultTestDependencyResolver extends DefaultDependencyResolver
-{
-}

--- a/src/test/java/org/codehaus/mojo/flatten/CreateEffectivePomTest.java
+++ b/src/test/java/org/codehaus/mojo/flatten/CreateEffectivePomTest.java
@@ -20,20 +20,10 @@ package org.codehaus.mojo.flatten;
  */
 
 import java.io.File;
-import java.lang.reflect.Field;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Properties;
 
-import org.apache.maven.artifact.factory.ArtifactFactory;
-import org.apache.maven.artifact.factory.DefaultArtifactFactory;
-import org.apache.maven.artifact.handler.ArtifactHandler;
-import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
-import org.apache.maven.artifact.handler.manager.DefaultArtifactHandlerManager;
-import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.repository.MavenArtifactRepository;
-import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.building.DefaultModelBuilderFactory;
 import org.apache.maven.model.building.DefaultModelBuildingRequest;
@@ -42,11 +32,10 @@ import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.model.building.ModelBuildingResult;
 import org.apache.maven.model.profile.ProfileInjector;
 import org.apache.maven.model.profile.ProfileSelector;
-import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.plugin.testing.MojoRule;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolver;
-import org.apache.maven.shared.transfer.dependencies.resolve.internal.DefaultTestDependencyResolver;
 import org.codehaus.mojo.flatten.model.resolution.FlattenModelResolver;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -58,8 +47,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class CreateEffectivePomTest
 {
-
-    FlattenMojo tested = new FlattenMojo();
+    @Rule
+    public MojoRule rule = new MojoRule();
 
     /**
      * Tests method to create effective POM.
@@ -76,33 +65,20 @@ public class CreateEffectivePomTest
         userProperties.setProperty( "cmd.test.property", magicValue );
 
         File pomFile = new File( "src/test/resources/cmdpropertysubstituion/pom.xml" );
-        ArtifactRepository localRepository = new MavenArtifactRepository();
-        localRepository.setLayout( new DefaultRepositoryLayout() );
-        ArtifactFactory artifactFactory = new DefaultArtifactFactory();
-        ArtifactHandlerManager artifactHandlerManager = new DefaultArtifactHandlerManager();
-        setDeclaredField( artifactFactory, "artifactHandlerManager", artifactHandlerManager );
-        Map<String, ArtifactHandler> artifactHandlers = new HashMap<String, ArtifactHandler>();
-        setDeclaredField( artifactHandlerManager, "artifactHandlers", artifactHandlers );
-        DependencyResolver depencencyResolver = new DefaultTestDependencyResolver();
-        DefaultProjectBuildingRequest projectBuildingRequest = new DefaultProjectBuildingRequest();
-        FlattenModelResolver resolver = new FlattenModelResolver( localRepository, artifactFactory,
-                                                                  depencencyResolver, projectBuildingRequest,
-                                                                  Collections.<MavenProject>emptyList() );
+        MavenProject mavenProject = rule.readMavenProject( pomFile.getParentFile() );
+
+        MavenSession session = rule.newMavenSession( mavenProject );
+        FlattenModelResolver resolver = new FlattenModelResolver( session.getRepositorySession(),
+                null, null, null, Collections.emptyList(), Collections.singletonList( mavenProject ) );
         ModelBuildingRequest buildingRequest =
             new DefaultModelBuildingRequest().setPomFile( pomFile ).setModelResolver( resolver )
                 .setUserProperties( userProperties );
-        setDeclaredField( tested, "modelBuilderThreadSafetyWorkaround",
+
+        FlattenMojo tested = (FlattenMojo) rule.lookupConfiguredMojo( mavenProject, "flatten" );
+        rule.setVariableValueToObject( tested, "modelBuilderThreadSafetyWorkaround",
                           buildModelBuilderThreadSafetyWorkaroundForTest() );
         Model effectivePom = tested.createEffectivePom( buildingRequest, false, FlattenMode.defaults );
         assertThat( effectivePom.getName() ).isEqualTo( magicValue );
-    }
-
-    private void setDeclaredField( Object pojo, String fieldName, Object propertyValue )
-        throws NoSuchFieldException, IllegalAccessException
-    {
-        Field field = pojo.getClass().getDeclaredField( fieldName );
-        field.setAccessible( true );
-        field.set( pojo, propertyValue );
     }
 
     /**
@@ -117,7 +93,6 @@ public class CreateEffectivePomTest
                                               ProfileSelector customSelector )
                 throws ModelBuildingException
             {
-
                 return new DefaultModelBuilderFactory().newInstance()
                     .setProfileInjector( customInjector )
                     .setProfileSelector( customSelector )


### PR DESCRIPTION
As part of user reported issue https://issues.apache.org/jira/browse/MRESOLVER-322 and for upcoming 1.9.5 resolver release went to look what it is about, only to figure out that this plugin accumulate several terrible lag, bad practice and many other things.

Whenever you see "inappropriate dependency" (ie. using MAT in plugin that declares itself as a 3.2.5+ plugin), use of deprecated components (ArtifactFactory, ArtifactRepository as local repository and relatives), or doing hoops and loops to get dependnecy graph ONLY to do something about it, step up and fix it. Or call the Ghostbusters!

These changes makes plugin work as expected from declared "minimum" version (3.2.5) to current stable (3.9.0) with addition that it will support split repository and any other modern feature incoming....

Lack of time prevented me to fully finish this PR.

There is one failing IT: 
```
[ERROR] The following builds failed:
[ERROR] *  profile-with-deps-inherit-parent-depMgmt-flatten-dep-all-active/pom.xml
```

**Someone please pick up this work, or will do it myself when get to it**