### PR TITLE
Make the default operation configurable

### DIFF
--- a/src/main/java/org/codehaus/mojo/flatten/FlattenDescriptor.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenDescriptor.java
@@ -35,6 +35,7 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 public class FlattenDescriptor {
 
     private final Map<String, ElementHandling> name2handlingMap;
+    private ElementHandling defaultOperation = ElementHandling.flatten;
 
     /**
      * The constructor.
@@ -59,6 +60,14 @@ public class FlattenDescriptor {
         }
     }
 
+    public ElementHandling getDefaultOperation() {
+        return defaultOperation;
+    }
+
+    public void setDefaultOperation(ElementHandling defaultOperation) {
+        this.defaultOperation = defaultOperation;
+    }
+
     /**
      * Generic method to get a {@link ElementHandling}.
      *
@@ -68,7 +77,7 @@ public class FlattenDescriptor {
     public ElementHandling getHandling(PomProperty<?> property) {
         ElementHandling handling = this.name2handlingMap.get(property.getName());
         if (handling == null) {
-            handling = ElementHandling.flatten;
+            handling = defaultOperation;
         }
         return handling;
     }

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -372,6 +372,14 @@ public class FlattenMojo extends AbstractFlattenMojo {
     @Parameter(property = "flatten.flatten.skip", defaultValue = "false")
     private boolean skipFlatten;
 
+    /**
+     * The default operation to use when no element handling is given. Defaults to <code>flatten</code>.
+     *
+     * @since 1.6.0
+     */
+    @Parameter(property = "flatten.dependency.defaultOperation", required = false, defaultValue = "flatten")
+    private ElementHandling defaultOperation;
+
     @Inject
     private DirectDependenciesInheritanceAssembler inheritanceAssembler;
 
@@ -791,10 +799,12 @@ public class FlattenMojo extends AbstractFlattenMojo {
                 Xpp3Dom rawDescriptor = this.mojoExecution.getConfiguration().getChild("pomElements");
                 descriptor = new FlattenDescriptor(rawDescriptor);
             }
+
             if (this.flattenMode != null) {
                 descriptor = descriptor.merge(this.flattenMode.getDescriptor());
             }
         }
+        descriptor.setDefaultOperation(defaultOperation);
         return descriptor;
     }
 


### PR DESCRIPTION
Make it possible to replace the default operation ("flatten") with
another value. This is useful to e.g. strip a pom completely and then
only add a few elements back.
