### PR TITLE
Add skip flags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   </parent>
 
   <artifactId>flatten-maven-plugin</artifactId>
-  <version>1.5.1-SNAPSHOT</version>
+  <version>1.6.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Maven Flatten Plugin</name>

--- a/src/it/projects/clean-skip/.flattened-pom.xml
+++ b/src/it/projects/clean-skip/.flattened-pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.flatten.its</groupId>
+  <artifactId>resolve-properties</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.mojo.flatten.its</groupId>
+      <artifactId>dep</artifactId>
+      <version>1.1</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/projects/clean-skip/pom.xml
+++ b/src/it/projects/clean-skip/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.flatten.its</groupId>
+  <artifactId>flatten-skip</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.mojo.flatten.its</groupId>
+      <artifactId>dep</artifactId>
+      <version>1.1</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <defaultGoal>verify</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <skipClean>true</skipClean>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/clean-skip/verify.groovy
+++ b/src/it/projects/clean-skip/verify.groovy
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Clean mojo is skipped so we should expect flattened pom to still exist
+File flattendPom = new File( basedir, '.flattened-pom.xml' )
+assert flattendPom.exists()
+
+

--- a/src/it/projects/flatten-skip/pom.xml
+++ b/src/it/projects/flatten-skip/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.flatten.its</groupId>
+  <artifactId>flatten-skip</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.mojo.flatten.its</groupId>
+      <artifactId>dep</artifactId>
+      <version>1.1</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <defaultGoal>verify</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/flatten-skip/verify.groovy
+++ b/src/it/projects/flatten-skip/verify.groovy
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Flatten mojo is skipped so we should expect no flattened pom
+File flattendPom = new File( basedir, '.flattened-pom.xml' )
+assert !flattendPom.exists()
+
+

--- a/src/it/projects/skip/.flattened-pom.xml
+++ b/src/it/projects/skip/.flattened-pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.flatten.its</groupId>
+  <artifactId>resolve-properties</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.mojo.flatten.its</groupId>
+      <artifactId>dep</artifactId>
+      <version>1.1</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/projects/skip/pom.xml
+++ b/src/it/projects/skip/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.flatten.its</groupId>
+  <artifactId>flatten-skip</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.mojo.flatten.its</groupId>
+      <artifactId>dep</artifactId>
+      <version>1.1</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <defaultGoal>verify</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/skip/verify.groovy
+++ b/src/it/projects/skip/verify.groovy
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Flatten plugin is skipped so we should expect that the flattened
+// pom is not removed by the clean mojo, and not newly created by the
+// flatten mojo, i.e. it is left unchanged. We can check this by
+// asserting it was last modified before starting to run this test
+File flattendPom = new File( basedir, '.flattened-pom.xml' )
+assert flattendPom.exists()
+long now = System.currentTimeMillis()
+assert now - flattendPom.lastModified() > 20*1000
+

--- a/src/main/java/org/codehaus/mojo/flatten/AbstractFlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/AbstractFlattenMojo.java
@@ -44,6 +44,12 @@ public abstract class AbstractFlattenMojo extends AbstractMojo {
     private String flattenedPomFilename;
 
     /**
+     * If {@code true} the plugin will be skipped.
+     */
+    @Parameter(property = "flatten.skip", defaultValue = "false")
+    private boolean skip;
+
+    /**
      * The constructor.
      */
     public AbstractFlattenMojo() {
@@ -71,4 +77,13 @@ public abstract class AbstractFlattenMojo extends AbstractMojo {
     protected File getFlattenedPomFile() {
         return new File(getOutputDirectory(), getFlattenedPomFilename());
     }
+
+    protected boolean shouldSkip() {
+        if (skip) {
+            return true;
+        }
+        return shouldSkipGoal();
+    }
+
+    protected abstract boolean shouldSkipGoal();
 }

--- a/src/main/java/org/codehaus/mojo/flatten/AbstractFlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/AbstractFlattenMojo.java
@@ -45,6 +45,8 @@ public abstract class AbstractFlattenMojo extends AbstractMojo {
 
     /**
      * If {@code true} the plugin will be skipped.
+     *
+     * @since 1.6.0
      */
     @Parameter(property = "flatten.skip", defaultValue = "false")
     private boolean skip;

--- a/src/main/java/org/codehaus/mojo/flatten/CleanMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/CleanMojo.java
@@ -45,6 +45,8 @@ public class CleanMojo extends AbstractFlattenMojo {
 
     /**
      * If {@code true} the clean goal will be skipped.
+     *
+     * @since 1.6.0
      */
     @Parameter(property = "flatten.clean.skip", defaultValue = "false")
     private boolean skipClean;

--- a/src/main/java/org/codehaus/mojo/flatten/CleanMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/CleanMojo.java
@@ -24,6 +24,7 @@ import java.io.File;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * This MOJO realizes the goal <code>flatten:clean</code> that deletes any files created by
@@ -43,6 +44,12 @@ import org.apache.maven.plugins.annotations.Mojo;
 public class CleanMojo extends AbstractFlattenMojo {
 
     /**
+     * If {@code true} the clean goal will be skipped.
+     */
+    @Parameter(property = "flatten.clean.skip", defaultValue = "false")
+    private boolean skipClean;
+
+    /**
      * The constructor.
      */
     public CleanMojo() {
@@ -53,6 +60,10 @@ public class CleanMojo extends AbstractFlattenMojo {
      * {@inheritDoc}
      */
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (shouldSkip()) {
+            getLog().info("Clean skipped.");
+            return;
+        }
 
         File flattenedPomFile = getFlattenedPomFile();
         if (flattenedPomFile.isFile()) {
@@ -62,5 +73,10 @@ public class CleanMojo extends AbstractFlattenMojo {
                 throw new MojoFailureException("Could not delete " + flattenedPomFile.getAbsolutePath());
             }
         }
+    }
+
+    @Override
+    protected boolean shouldSkipGoal() {
+        return skipClean;
     }
 }

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -366,6 +366,8 @@ public class FlattenMojo extends AbstractFlattenMojo {
 
     /**
      * If {@code true} the flatten goal will be skipped.
+     *
+     * @since 1.6.0
      */
     @Parameter(property = "flatten.flatten.skip", defaultValue = "false")
     private boolean skipFlatten;

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -364,6 +364,12 @@ public class FlattenMojo extends AbstractFlattenMojo {
     @Parameter(property = "flatten.dependency.keepComments", required = false, defaultValue = "false")
     private boolean keepCommentsInPom;
 
+    /**
+     * If {@code true} the flatten goal will be skipped.
+     */
+    @Parameter(property = "flatten.flatten.skip", defaultValue = "false")
+    private boolean skipFlatten;
+
     @Inject
     private DirectDependenciesInheritanceAssembler inheritanceAssembler;
 
@@ -400,6 +406,10 @@ public class FlattenMojo extends AbstractFlattenMojo {
      */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (shouldSkip()) {
+            getLog().info("Flatten skipped.");
+            return;
+        }
 
         getLog().info("Generating flattened POM of project " + this.project.getId() + "...");
 
@@ -420,6 +430,11 @@ public class FlattenMojo extends AbstractFlattenMojo {
             this.project.setPomFile(flattenedPomFile);
             this.project.setOriginalModel(flattenedPom);
         }
+    }
+
+    @Override
+    protected boolean shouldSkipGoal() {
+        return skipFlatten;
     }
 
     /**


### PR DESCRIPTION
This introduces 3 flags:
- `flatten.skip`: skips the entire plugin regardless of goal
- `flatten.clean.skip`: skips the clean goal
- `flatten.flatten.skip`: skips the flatten goal

This means the user has control over what parts are skipped, and the flags are descriptive. The `flatten.` prefix is in line with other parameters like `flatten.mode` and `flatten.dependency.mode`.

Test cases have been added for all three flags. Of course, I also tested it locally. The resulting logs are as follows:

```
[INFO] --- flatten:1.5.1-SNAPSHOT:clean (flatten.clean) @ my-test-module ---
[INFO] Clean skipped.
```

```
[INFO] --- flatten:1.5.1-SNAPSHOT:flatten (flatten) @ my-test-module ---
[INFO] Flatten skipped.
```

Usage is either through passing parameters along with the command:
```sh
mvn <goal> -Dflatten.skip
mvn <goal> -Dflatten.clean.skip
mvn <goal> -Dflatten.flatten.skip
```

Or through the configuration:
```xml
<configuration>
  <skip>false</skip>
  <skipClean>false</skipClean>
  <skipFlatten>true</skipFlatten>
</<configuration>
```

closes #290 