### PR TITLE
Fix Issue#377 Regression: parent dependencies missing in flattened pom

### DIFF
--- a/src/it/mrm/repository/parent-transitive-deps-1.pom
+++ b/src/it/mrm/repository/parent-transitive-deps-1.pom
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.codehaus.mojo.flatten.its</groupId>
+    <artifactId>parent-transitive-dep</artifactId>
+    <version>1</version>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.codehaus.mojo.flatten.its</groupId>
+            <artifactId>core</artifactId>
+            <version>3.2.1</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/it/projects/complete-multimodule-parent-pom-direct-dependencies/pom.xml
+++ b/src/it/projects/complete-multimodule-parent-pom-direct-dependencies/pom.xml
@@ -14,6 +14,9 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
+        <configuration>
+          <flattenDependencyMode>direct</flattenDependencyMode>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/it/projects/inherit-parent-dependency/pom.xml
+++ b/src/it/projects/inherit-parent-dependency/pom.xml
@@ -4,21 +4,9 @@
 
   <parent>
     <groupId>org.codehaus.mojo.flatten.its</groupId>
-    <artifactId>parent-deps</artifactId>
+    <artifactId>parent-transitive-dep</artifactId>
     <version>1</version>
   </parent>
   <artifactId>resolve-properties</artifactId>
   <version>0.0.1-SNAPSHOT</version>
-  <build>
-    <defaultGoal>verify</defaultGoal>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-          <artifactId>flatten-maven-plugin</artifactId>
-          <configuration>
-            <flattenDependencyMode>all</flattenDependencyMode>
-          </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/src/it/projects/parent-with-version-range/pom.xml
+++ b/src/it/projects/parent-with-version-range/pom.xml
@@ -1,25 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.codehaus.mojo.flatten.its</groupId>
-    <artifactId>parent-deps</artifactId>
-    <version>[0,2]</version>
-  </parent>
+    <parent>
+        <groupId>org.codehaus.mojo.flatten.its</groupId>
+        <artifactId>parent-deps</artifactId>
+        <version>[0,2]</version>
+    </parent>
 
     <artifactId>parent-with-version-range</artifactId>
     <version>0.0.1-SNAPSHOT</version>
-  <build>
-    <defaultGoal>verify</defaultGoal>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-          <artifactId>flatten-maven-plugin</artifactId>
-          <configuration>
-            <flattenDependencyMode>all</flattenDependencyMode>
-          </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/src/main/java/org/codehaus/mojo/flatten/DirectDependenciesInheritanceAssembler.java
+++ b/src/main/java/org/codehaus/mojo/flatten/DirectDependenciesInheritanceAssembler.java
@@ -144,7 +144,7 @@ public class DirectDependenciesInheritanceAssembler extends DefaultInheritanceAs
         @Override
         protected void mergeModelBase_Dependencies(
                 ModelBase target, ModelBase source, boolean sourceDominant, Map<Object, Object> context) {
-            if (flattenDependencyMode == null || flattenDependencyMode == FlattenDependencyMode.direct) {
+            if (flattenDependencyMode == FlattenDependencyMode.direct) {
                 return;
             }
             super.mergeModelBase_Dependencies(target, source, sourceDominant, context);

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenDependencyMode.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenDependencyMode.java
@@ -27,13 +27,18 @@ package org.codehaus.mojo.flatten;
  */
 public enum FlattenDependencyMode {
     /**
-     * Flatten only the direct dependency versions. This is the default mode and compatible with
-     * Flatten Plugin prior to 1.2.0.
+     * Flatten only the direct dependency versions, excluding inherited dependencies from a parent module.
      */
     direct,
 
     /**
-     * Flatten both direct and transitive dependencies. This will examine the full dependency tree, and pull up
+     * Flatten dependencies, including inherited dependencies from a parent module.
+     * This is the default mode and compatible with Flatten Plugin prior to 1.2.0.
+     */
+    inherited,
+
+    /**
+     * Flatten both direct, inherited and transitive dependencies. This will examine the full dependency tree, and pull up
      * all transitive dependencies as a direct dependency, and setting their versions appropriately.
      *
      * This is recommended if you are releasing a library that uses dependency management to manage dependency

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -339,8 +339,16 @@ public class FlattenMojo extends AbstractFlattenMojo {
      * </thead><tbody>
      * <tr>
      * <td>direct</td>
-     * <td>Flatten only the direct dependency versions.
-     * This is the default mode and compatible with Flatten Plugin prior to 1.2.0.</td>
+     * <td><p>Flatten only the direct dependency versions, excluding inherited dependencies from a parent module.</p>
+     * <p>This was the default mode with Flatten Plugin in versions 1.4.0 up to 1.6.0.
+     * </td>
+     * </tr>
+     * <tr>
+     * <td>inherited</td>
+     * <td><p>Flatten the dependency versions, including inherited dependencies from a parent module</p>
+     * <p>This is the default mode and compatible with Flatten Plugin prior to 1.2.0, this mode was called <tt>direct</tt> between versions 1.2.0 and 1.3.0.</p>
+     * </td>
+     * </tr>
      * <tr>
      * <td>all</td>
      * <td><p>Flatten both direct and transitive dependencies. This will examine the full dependency tree, and pull up
@@ -1217,7 +1225,9 @@ public class FlattenMojo extends AbstractFlattenMojo {
         // List<Dependency> projectDependencies = currentProject.getOriginalModel().getDependencies();
         List<Dependency> projectDependencies = effectiveModel.getDependencies();
 
-        if (flattenDependencyMode == null | flattenDependencyMode == FlattenDependencyMode.direct) {
+        if (flattenDependencyMode == null
+                || flattenDependencyMode == FlattenDependencyMode.direct
+                || flattenDependencyMode == FlattenDependencyMode.inherited) {
             createFlattenedDependenciesDirect(projectDependencies, flattenedDependencies);
         } else if (flattenDependencyMode == FlattenDependencyMode.all) {
             try {


### PR DESCRIPTION
... since 1.4.0. Introduce a new "inherited" flatten dependency mode that includes the inherited dependencies like "direct" did in 1.3.0. And make this the new default behaviour bringing it back to 1.3.0 and before