### PR TITLE
remove pom properties revision property

### DIFF
--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -610,6 +610,13 @@ public class FlattenMojo extends AbstractFlattenMojo {
             }
         }
 
+        // remove pom.xml properties revision property
+        String oldVersion = originalPom.getVersion();
+        if (oldVersion != null && !oldVersion.isEmpty() && oldVersion.startsWith("${") && oldVersion.endsWith("}")) {
+            getLog().info("find version " + oldVersion + " remove to properties");
+            flattenedPom.getProperties().remove(oldVersion.substring(2, oldVersion.length() - 1));
+        }
+
         return flattenedPom;
     }
 
@@ -922,9 +929,9 @@ public class FlattenMojo extends AbstractFlattenMojo {
                     }
                 }
             };
-
             buildingResult = modelBuilderThreadSafetyWorkaround.build(
                     buildingRequest, customInjector, new DefaultProfileSelector());
+
         } catch (ModelBuildingException e) {
             throw new MojoExecutionException(e.getMessage(), e);
         }


### PR DESCRIPTION
one project use  flatten-maven-plugin  define revision in   parent project ,   other project  use  this pom to parent pom ,  the other project  have use  flatten-maven-plugin  define revision ，avoid effect 