### PR TITLE
Fix for #408, ensure nested dependency exclusions aren't overrided

### DIFF
--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -1,24 +1,5 @@
 package org.codehaus.mojo.flatten;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 import javax.inject.Inject;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -1121,10 +1102,6 @@ public class FlattenMojo extends AbstractFlattenMojo {
         for (Dependency dependency : projectDependencies) {
             collectRequest.addDependency(RepositoryUtils.toDependency(
                     dependency, session.getRepositorySession().getArtifactTypeRegistry()));
-        }
-
-        for (Artifact artifact : project.getArtifacts()) {
-            collectRequest.addDependency(RepositoryUtils.toDependency(artifact, null));
         }
 
         for (Dependency dependency : managedDependencies) {

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -1123,6 +1123,11 @@ public class FlattenMojo extends AbstractFlattenMojo {
                     dependency, session.getRepositorySession().getArtifactTypeRegistry()));
         }
 
+        for (Dependency dependency : project.getDependencies()) {
+            collectRequest.addDependency(RepositoryUtils.toDependency(
+                    dependency, session.getRepositorySession().getArtifactTypeRegistry()));
+        }
+
         for (Dependency dependency : managedDependencies) {
             collectRequest.addManagedDependency(RepositoryUtils.toDependency(
                     dependency, session.getRepositorySession().getArtifactTypeRegistry()));

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -1122,10 +1122,6 @@ public class FlattenMojo extends AbstractFlattenMojo {
         CollectRequest collectRequest = new CollectRequest();
         collectRequest.setRepositories(project.getRemoteProjectRepositories());
         collectRequest.setRootArtifact(RepositoryUtils.toArtifact(projectArtifact));
-        for (Dependency dependency : projectDependencies) {
-            collectRequest.addDependency(RepositoryUtils.toDependency(
-                    dependency, session.getRepositorySession().getArtifactTypeRegistry()));
-        }
 
         for (Dependency dependency : project.getDependencies()) {
             collectRequest.addDependency(RepositoryUtils.toDependency(
@@ -1149,7 +1145,7 @@ public class FlattenMojo extends AbstractFlattenMojo {
         resolveConflicts(derived, root);
 
         final Set<String> directDependencyKeys = Stream.concat(
-                        projectDependencies.stream().map(this::getKey),
+                        project.getDependencies().stream().map(this::getKey),
                         project.getArtifacts().stream().map(this::getKey))
                 .collect(Collectors.toSet());
 

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -1538,7 +1538,7 @@ public class FlattenMojo extends AbstractFlattenMojo {
      * Default implementation of {@link DependencyGraphTransformationContext}.
      * As maven libraries do not expose an implementation, we need to provide our own.
      */
-    class DefaultDependencyGraphTransformationContext implements DependencyGraphTransformationContext {
+    static class DefaultDependencyGraphTransformationContext implements DependencyGraphTransformationContext {
 
         private final RepositorySystemSession session;
 

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -1151,6 +1151,12 @@ public class FlattenMojo extends AbstractFlattenMojo {
                 if (root == node) {
                     return true;
                 }
+
+                if (node.getData().containsKey(ConflictResolver.NODE_DATA_WINNER)) {
+                    // if this node has a conflict winner in data, it means this node lost in conflict
+                    return false; // skip lost conflicts
+                }
+
                 if (JavaScopes.PROVIDED.equals(node.getDependency().getScope())) {
                     String dependencyKey = getKey(node.getDependency());
                     if (!directDependencyKeys.contains(dependencyKey)) {

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -1,5 +1,24 @@
 package org.codehaus.mojo.flatten;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import javax.inject.Inject;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -1549,6 +1549,7 @@ public class FlattenMojo extends AbstractFlattenMojo {
             this.map = new HashMap<>();
         }
 
+        @Override
         public RepositorySystemSession getSession() {
             return session;
         }

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -1558,6 +1558,7 @@ public class FlattenMojo extends AbstractFlattenMojo {
             return map.get(Objects.requireNonNull(key, "key cannot be null"));
         }
 
+        @Override
         public Object put(Object key, Object value) {
             Objects.requireNonNull(key, "key cannot be null");
             if (value != null) {

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -1554,6 +1554,7 @@ public class FlattenMojo extends AbstractFlattenMojo {
             return session;
         }
 
+        @Override
         public Object get(Object key) {
             return map.get(Objects.requireNonNull(key, "key cannot be null"));
         }

--- a/src/test/java/org/codehaus/mojo/flatten/FlattenMojoConflictWinnerTest.java
+++ b/src/test/java/org/codehaus/mojo/flatten/FlattenMojoConflictWinnerTest.java
@@ -45,7 +45,7 @@ public class FlattenMojoConflictWinnerTest {
     public MojoRule rule = new MojoRule();
 
     /**
-     * Test method to check that version conflict are correctly honored. Two levels
+     * Test method to check that version conflicts are correctly honored. Two levels
      * of dependencies are defined for this test:
      * <ul>
      * <li>A depends on B 0.0.1</li>

--- a/src/test/java/org/codehaus/mojo/flatten/FlattenMojoConflictWinnerTest.java
+++ b/src/test/java/org/codehaus/mojo/flatten/FlattenMojoConflictWinnerTest.java
@@ -1,0 +1,143 @@
+package org.codehaus.mojo.flatten;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.DefaultMavenExecutionResult;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.execution.MavenExecutionResult;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.testing.MojoRule;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.project.ProjectBuildingResult;
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.LocalRepositoryManager;
+import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Test-Case for {@link FlattenMojo}.
+ */
+public class FlattenMojoConflictWinnerTest {
+
+    private static final String PATH = "src/test/resources/conflict-winner/";
+    private static final String POM = PATH + "pom.xml";
+    private static final String FLATTENED_POM = PATH + ".flattened-pom.xml";
+
+    private static final String REPO_PATH = "src/test/resources/conflict-winner/repository/";
+
+    @Rule
+    public MojoRule rule = new MojoRule();
+
+    /**
+     * Test method to check that version conflict are correctly honored. Two levels
+     * of dependencies are defined for this test:
+     * <ul>
+     * <li>A depends on B 0.0.1</li>
+     * <li>B 0.0.2</li>
+     * </ul>
+     *
+     * The tested pom depends on A and B. It is then expected that B use version
+     * 0.0.2 in the flattened pom because B 0.0.2 is closer to the root.
+     *
+     * 1.7.3 of the plugin was handling this case correctly but since solving #408
+     * it is not the case anymore. By removing resolved transitive dependencies from
+     * the collect request parameters, the conflict resolution is not applied anymore
+     * as resolved transitive dependencies does not appear first anymore. This test ensure
+     * that the conflicting dependencies are correctly filtered from collect
+     * results and the winner version is kept.
+     * 
+     * @see <a href=
+     *      "https://github.com/mojohaus/flatten-maven-plugin/issues/408">Issue
+     *      #408</a>
+     *
+     * @since 1.7.3+
+     * @throws Exception if something goes wrong.
+     */
+    @Test
+    public void testNestedExclusionAreEnforced() throws Exception {
+
+        MavenSession session = newMavenSession(REPO_PATH);
+        MavenProject project = loadResolvedProject(session, new File(POM));
+        FlattenMojo flattenMojo = (FlattenMojo) rule.lookupConfiguredMojo(project, "flatten");
+        rule.setVariableValueToObject(flattenMojo, "session", session);
+
+        flattenMojo.execute();
+
+        MavenProject flattenedProject = loadResolvedProject(session, new File(FLATTENED_POM));
+
+        flattenedProject.getDependencies().stream()
+                .filter(dep -> dep.getArtifactId().equals("b"))
+                .filter(dep -> dep.getVersion().equals("0.0.1"))
+                .findAny()
+                .ifPresent(dep -> fail(
+                        "B dependency version 0.0.2 must win the conflicting version match in flattened POM."));
+    }
+
+    /**
+     * Load a maven project with resolved dependencies (same as standard maven execution).
+     * By default dependencies are not resolved by MojoRule and project.getArtifacts is empty
+     * @param session the Maven session to use for building the project
+     * @param pomFile the POM file to load and resolve dependencies for
+     * @return the resolved MavenProject instance with dependencies
+     * @throws ComponentLookupException if the ProjectBuilder component cannot be found
+     * @throws ProjectBuildingException if an error occurs while building the project
+     */
+    private MavenProject loadResolvedProject(MavenSession session, File pomFile)
+            throws ComponentLookupException, ProjectBuildingException {
+        ProjectBuilder projectBuilder = rule.lookup(ProjectBuilder.class);
+
+        ProjectBuildingRequest buildingRequest = session.getProjectBuildingRequest();
+        buildingRequest.setResolveDependencies(true);
+
+        ProjectBuildingResult result = projectBuilder.build(pomFile, buildingRequest);
+        return result.getProject();
+    }
+
+    /**
+     * Create a new maven session with a local repository at the given path.
+     * @param repoPath the path to the local repository to use for the session
+     * @return a new MavenSession instance configured with the specified local repository
+     * @throws NoLocalRepositoryManagerException if the local repository manager cannot be created
+     */
+    protected MavenSession newMavenSession(String repoPath) throws NoLocalRepositoryManagerException {
+        MavenExecutionRequest request = new DefaultMavenExecutionRequest();
+        MavenExecutionResult result = new DefaultMavenExecutionResult();
+
+        MavenSession session =
+                new MavenSession(rule.getContainer(), MavenRepositorySystemUtils.newSession(), request, result);
+        LocalRepository testRepo = new LocalRepository(repoPath);
+        LocalRepositoryManager lrm =
+                new SimpleLocalRepositoryManagerFactory().newInstance(session.getRepositorySession(), testRepo);
+
+        ((DefaultRepositorySystemSession) session.getRepositorySession()).setLocalRepositoryManager(lrm);
+        return session;
+    }
+
+    /**
+     * After test method. Removes flattened-pom.xml file which is created during test.
+     *
+     * @throws IOException if can't remove file.
+     */
+    @After
+    public void removeFlattenedPom() throws IOException {
+        File flattenedPom = new File(FLATTENED_POM);
+        if (flattenedPom.exists()) {
+            if (!flattenedPom.delete()) {
+                throw new IOException("Can't delete " + flattenedPom);
+            }
+        }
+    }
+}

--- a/src/test/java/org/codehaus/mojo/flatten/FlattenMojoConflictWinnerTest.java
+++ b/src/test/java/org/codehaus/mojo/flatten/FlattenMojoConflictWinnerTest.java
@@ -58,7 +58,7 @@ public class FlattenMojoConflictWinnerTest {
      * as resolved transitive dependencies does not appear first anymore. This test ensure
      * that the conflicting dependencies are correctly filtered from collect
      * results and the winner version is kept.
-     * 
+     *
      * @see <a href=
      *      "https://github.com/mojohaus/flatten-maven-plugin/issues/408">Issue
      *      #408</a>
@@ -82,8 +82,8 @@ public class FlattenMojoConflictWinnerTest {
                 .filter(dep -> dep.getArtifactId().equals("b"))
                 .filter(dep -> dep.getVersion().equals("0.0.1"))
                 .findAny()
-                .ifPresent(dep -> fail(
-                        "B dependency version 0.0.2 must win the conflicting version match in flattened POM."));
+                .ifPresent(dep ->
+                        fail("B dependency version 0.0.2 must win the conflicting version match in flattened POM."));
     }
 
     /**

--- a/src/test/java/org/codehaus/mojo/flatten/FlattenMojoNestedExclusionTest.java
+++ b/src/test/java/org/codehaus/mojo/flatten/FlattenMojoNestedExclusionTest.java
@@ -1,7 +1,5 @@
 package org.codehaus.mojo.flatten;
 
-import static org.junit.Assert.fail;
-
 import java.io.File;
 import java.io.IOException;
 
@@ -26,6 +24,8 @@ import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.junit.Assert.fail;
 
 /**
  * Test-Case for {@link FlattenMojo}.

--- a/src/test/java/org/codehaus/mojo/flatten/FlattenMojoNestedExclusionTest.java
+++ b/src/test/java/org/codehaus/mojo/flatten/FlattenMojoNestedExclusionTest.java
@@ -1,0 +1,136 @@
+package org.codehaus.mojo.flatten;
+
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.DefaultMavenExecutionResult;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.execution.MavenExecutionResult;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.testing.MojoRule;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.project.ProjectBuildingResult;
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.LocalRepositoryManager;
+import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test-Case for {@link FlattenMojo}.
+ *
+ * @author treilhes
+ */
+public class FlattenMojoNestedExclusionTest {
+
+    private static final String PATH = "src/test/resources/nested-exclusion/";
+    private static final String POM = PATH + "pom.xml";
+    private static final String FLATTENED_POM = PATH + ".flattened-pom.xml";
+
+    private static final String REPO_PATH = "src/test/resources/nested-exclusion/repository/";
+
+    @Rule
+    public MojoRule rule = new MojoRule();
+
+    /**
+     * Test method to check that nested exclusion are correctly honored.
+     * Three levels of dependencies are defined for this test:
+     * <ul>
+     * <li>A depends on B with B excluding C</li>
+     * <li>B depends on C</li>
+     * </ul>
+     *
+     * The tested pom depends on A only. It is then expected that C is not present in the flattened pom.
+     * Only A and B should be present.
+     *
+     * 1.3.0 of the plugin was handling this case correctly but since 1.4.0 it is not the case anymore.
+     * @see <a href="https://github.com/mojohaus/flatten-maven-plugin/issues/408">Issue #408</a>
+     *
+     * @since 1.7.2+
+     * @throws Exception if something goes wrong.
+     */
+    @Test
+    public void testNestedExclusionAreEnforced() throws Exception {
+
+        MavenSession session = newMavenSession(REPO_PATH);
+        MavenProject project = loadResolvedProject(session, new File(POM));
+        FlattenMojo flattenMojo = (FlattenMojo) rule.lookupConfiguredMojo(project, "flatten");
+        rule.setVariableValueToObject(flattenMojo, "session", session);
+
+        flattenMojo.execute();
+
+        MavenProject flattenedProject = loadResolvedProject(session, new File(FLATTENED_POM));
+
+        flattenedProject.getDependencies().stream()
+                .filter(dep -> dep.getArtifactId().equals("c"))
+                .findAny()
+                .ifPresent(dep -> fail(
+                        "As B dependency in A is excluding C, no C dependency should be present in flattened POM."));
+    }
+
+    /**
+     * Load a maven project with resolved dependencies (same as standard maven execution).
+     * By default dependencies are not resolved by MojoRule and project.getArtifacts is empty
+     * @param session
+     * @param pomFile
+     * @return
+     * @throws ComponentLookupException
+     * @throws ProjectBuildingException
+     */
+    private MavenProject loadResolvedProject(MavenSession session, File pomFile)
+            throws ComponentLookupException, ProjectBuildingException {
+        ProjectBuilder projectBuilder = rule.lookup(ProjectBuilder.class);
+
+        ProjectBuildingRequest buildingRequest = session.getProjectBuildingRequest();
+        buildingRequest.setResolveDependencies(true);
+
+        ProjectBuildingResult result = projectBuilder.build(pomFile, buildingRequest);
+        return result.getProject();
+    }
+
+    /**
+     * Create a new maven session with a local repository at the given path.
+     * @param repoPath
+     * @return
+     * @throws NoLocalRepositoryManagerException
+     */
+    protected MavenSession newMavenSession(String repoPath) throws NoLocalRepositoryManagerException {
+        MavenExecutionRequest request = new DefaultMavenExecutionRequest();
+        MavenExecutionResult result = new DefaultMavenExecutionResult();
+
+        MavenSession session =
+                new MavenSession(rule.getContainer(), MavenRepositorySystemUtils.newSession(), request, result);
+        LocalRepository testRepo = new LocalRepository(repoPath);
+        LocalRepositoryManager lrm =
+                new SimpleLocalRepositoryManagerFactory().newInstance(session.getRepositorySession(), testRepo);
+
+        ((DefaultRepositorySystemSession) session.getRepositorySession()).setLocalRepositoryManager(lrm);
+        return session;
+    }
+
+    /**
+     * After test method. Removes flattened-pom.xml file which is created during test.
+     *
+     * @throws IOException if can't remove file.
+     */
+    @After
+    public void removeFlattenedPom() throws IOException {
+        File flattenedPom = new File(FLATTENED_POM);
+        if (flattenedPom.exists()) {
+            if (!flattenedPom.delete()) {
+                throw new IOException("Can't delete " + flattenedPom);
+            }
+        }
+    }
+}

--- a/src/test/java/org/codehaus/mojo/flatten/FlattenMojoNestedExclusionTest.java
+++ b/src/test/java/org/codehaus/mojo/flatten/FlattenMojoNestedExclusionTest.java
@@ -45,7 +45,7 @@ public class FlattenMojoNestedExclusionTest {
      * Test method to check that nested exclusion are correctly honored.
      * Three levels of dependencies are defined for this test:
      * <ul>
-     * <li>A depends on B with A excluding C trough B</li>
+     * <li>A depends on B with A excluding C through B</li>
      * <li>B depends on C</li>
      * </ul>
      *

--- a/src/test/java/org/codehaus/mojo/flatten/FlattenMojoNestedExclusionTest.java
+++ b/src/test/java/org/codehaus/mojo/flatten/FlattenMojoNestedExclusionTest.java
@@ -29,8 +29,6 @@ import static org.junit.Assert.fail;
 
 /**
  * Test-Case for {@link FlattenMojo}.
- *
- * @author treilhes
  */
 public class FlattenMojoNestedExclusionTest {
 
@@ -47,7 +45,7 @@ public class FlattenMojoNestedExclusionTest {
      * Test method to check that nested exclusion are correctly honored.
      * Three levels of dependencies are defined for this test:
      * <ul>
-     * <li>A depends on B with B excluding C</li>
+     * <li>A depends on B with A excluding C trough B</li>
      * <li>B depends on C</li>
      * </ul>
      *
@@ -82,11 +80,11 @@ public class FlattenMojoNestedExclusionTest {
     /**
      * Load a maven project with resolved dependencies (same as standard maven execution).
      * By default dependencies are not resolved by MojoRule and project.getArtifacts is empty
-     * @param session
-     * @param pomFile
-     * @return
-     * @throws ComponentLookupException
-     * @throws ProjectBuildingException
+     * @param session the Maven session to use for building the project
+     * @param pomFile the POM file to load and resolve dependencies for
+     * @return the resolved MavenProject instance with dependencies
+     * @throws ComponentLookupException if the ProjectBuilder component cannot be found
+     * @throws ProjectBuildingException if an error occurs while building the project
      */
     private MavenProject loadResolvedProject(MavenSession session, File pomFile)
             throws ComponentLookupException, ProjectBuildingException {
@@ -101,9 +99,9 @@ public class FlattenMojoNestedExclusionTest {
 
     /**
      * Create a new maven session with a local repository at the given path.
-     * @param repoPath
-     * @return
-     * @throws NoLocalRepositoryManagerException
+     * @param repoPath the path to the local repository to use for the session
+     * @return a new MavenSession instance configured with the specified local repository
+     * @throws NoLocalRepositoryManagerException if the local repository manager cannot be created
      */
     protected MavenSession newMavenSession(String repoPath) throws NoLocalRepositoryManagerException {
         MavenExecutionRequest request = new DefaultMavenExecutionRequest();

--- a/src/test/resources/conflict-winner/pom.xml
+++ b/src/test/resources/conflict-winner/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.codehaus.mojo.flatten.its</groupId>
+	<artifactId>conflict-winner</artifactId>
+	<version>${revision}</version>
+
+	<properties>
+		<revision>1.2.3.4</revision>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>flatten-maven-plugin</groupId>
+			<artifactId>a</artifactId>
+			<version>0.0.1</version>
+		</dependency>
+		<dependency>
+			<groupId>flatten-maven-plugin</groupId>
+			<artifactId>b</artifactId>
+			<version>0.0.2</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<defaultGoal>verify</defaultGoal>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<configuration>
+					<flattenMode>bom</flattenMode>
+					<flattenDependencyMode>all</flattenDependencyMode>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/test/resources/conflict-winner/repository/flatten-maven-plugin/a/0.0.1/a-0.0.1.pom
+++ b/src/test/resources/conflict-winner/repository/flatten-maven-plugin/a/0.0.1/a-0.0.1.pom
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>flatten-maven-plugin</groupId>
+	<artifactId>a</artifactId>
+	<version>0.0.1</version>
+
+	<dependencies>
+		<dependency>
+			<groupId>flatten-maven-plugin</groupId>
+			<artifactId>b</artifactId>
+			<version>0.0.1</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/src/test/resources/conflict-winner/repository/flatten-maven-plugin/b/0.0.1/b-0.0.1.pom
+++ b/src/test/resources/conflict-winner/repository/flatten-maven-plugin/b/0.0.1/b-0.0.1.pom
@@ -1,0 +1,9 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>flatten-maven-plugin</groupId>
+	<artifactId>b</artifactId>
+	<version>0.0.1</version>
+
+</project>

--- a/src/test/resources/conflict-winner/repository/flatten-maven-plugin/b/0.0.2/b-0.0.2.pom
+++ b/src/test/resources/conflict-winner/repository/flatten-maven-plugin/b/0.0.2/b-0.0.2.pom
@@ -1,0 +1,9 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>flatten-maven-plugin</groupId>
+	<artifactId>b</artifactId>
+	<version>0.0.2</version>
+
+</project>

--- a/src/test/resources/nested-exclusion/pom.xml
+++ b/src/test/resources/nested-exclusion/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.codehaus.mojo.flatten.its</groupId>
+	<artifactId>nested-exclusion</artifactId>
+	<version>${revision}</version>
+
+	<properties>
+		<revision>1.2.3.4</revision>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>flatten-maven-plugin</groupId>
+			<artifactId>a</artifactId>
+			<version>0.0.1</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+	    <defaultGoal>verify</defaultGoal>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<configuration>
+					<flattenMode>bom</flattenMode>
+					<flattenDependencyMode>all</flattenDependencyMode>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/test/resources/nested-exclusion/repository/flatten-maven-plugin/a/0.0.1/a-0.0.1.pom
+++ b/src/test/resources/nested-exclusion/repository/flatten-maven-plugin/a/0.0.1/a-0.0.1.pom
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>flatten-maven-plugin</groupId>
+	<artifactId>a</artifactId>
+	<version>0.0.1</version>
+
+	<dependencies>
+		<dependency>
+			<groupId>flatten-maven-plugin</groupId>
+			<artifactId>b</artifactId>
+			<version>0.0.1</version>
+			<exclusions>
+				<exclusion>
+					<groupId>flatten-maven-plugin</groupId>
+					<artifactId>c</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
+</project>

--- a/src/test/resources/nested-exclusion/repository/flatten-maven-plugin/b/0.0.1/b-0.0.1.pom
+++ b/src/test/resources/nested-exclusion/repository/flatten-maven-plugin/b/0.0.1/b-0.0.1.pom
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>flatten-maven-plugin</groupId>
+	<artifactId>b</artifactId>
+	<version>0.0.1</version>
+
+	<dependencies>
+		<dependency>
+			<groupId>flatten-maven-plugin</groupId>
+			<artifactId>c</artifactId>
+			<version>0.0.1</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/src/test/resources/nested-exclusion/repository/flatten-maven-plugin/c/0.0.1/c-0.0.1.pom
+++ b/src/test/resources/nested-exclusion/repository/flatten-maven-plugin/c/0.0.1/c-0.0.1.pom
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>flatten-maven-plugin</groupId>
+  <artifactId>c</artifactId>
+  <version>0.0.1</version>
+  
+</project>


### PR DESCRIPTION
Hi,

This PR try to solve #408, dependencies are present in the flattened POM even when excluded in a nested dependency of a project.

From my understanding the issue comes from https://github.com/mojohaus/flatten-maven-plugin/blob/75a39891298b80fcc692e72222aece0d2b0e5671/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java#L1126

project.getArtifacts() returns all project's resolved artifacts which is ok but using those artifacts as dependencies in the CollectRequest transforms those dependencies as if they were direct ones and by doing so removes any exclusions that may have been set in the nested dependency POM.

I think projectDependencies and managedDependencies are sufficient so the whole loop is unnecessary and can be safely removed:

```
for (Artifact artifact : project.getArtifacts()) {
    collectRequest.addDependency(RepositoryUtils.toDependency(artifact, null));
}
```

As I'm not familiar with all the ins and outs of this project i'm not 100% sure of my analysis so please take this removal with caution

A unit test has been added demonstrating the case.
Don't hesitate to request changes if needed