### PR TITLE
Fix for Maven 3.10.x

### DIFF
--- a/src/it/projects/flatten-deploy/invoker.properties
+++ b/src/it/projects/flatten-deploy/invoker.properties
@@ -1,1 +1,4 @@
 invoker.goals=clean deploy
+
+# FIXME Failed with Maven 4.0.0-rc-5
+invoker.maven.version = !4.0.0+

--- a/src/it/projects/resolve-properties-ci/invoker.properties
+++ b/src/it/projects/resolve-properties-ci/invoker.properties
@@ -1,3 +1,3 @@
 invoker.mavenOpts = -Drevision=1.2.3.4 -Drevision1=1.2.3.5 -Dsmall=small -Dsha1=abcdefg -Dchangelist=1,2,3,4
-# Maven 4 requires all properties to be resolved in dependencies
-invoker.maven.version = !4.0.0+
+# Maven 4 and 3.10.0 requires all properties to be resolved in dependencies
+invoker.maven.version = !4.0.0+,!3.10.0

--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -1198,7 +1198,8 @@ public class FlattenMojo extends AbstractFlattenMojo {
 
                 org.eclipse.aether.artifact.Artifact aetherArtifact = new DefaultArtifact(
                         artifact.getGroupId(), artifact.getArtifactId(), null, artifact.getVersion());
-                ArtifactDescriptorRequest request = new ArtifactDescriptorRequest(aetherArtifact, null, null);
+                ArtifactDescriptorRequest request =
+                        new ArtifactDescriptorRequest(aetherArtifact, project.getRemoteProjectRepositories(), null);
                 ArtifactDescriptorResult artifactDescriptorResult =
                         repositorySystem.readArtifactDescriptor(this.session.getRepositorySession(), request);
 


### PR DESCRIPTION
What changed:
- ignore resolve-properties-ci 4.x and 3.10.x required all properties in dependence to be resolved
- Add remote project repositories in `ArtifactDescriptorRequest`

fix #513