### PR TITLE
Stop dependabot from updating test fixtures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,9 @@ version: 2
 updates:
   - package-ecosystem: "maven"
     directory: "/"
+    exclude-paths:
+      - "src/it/**"
+      - "src/test/resources/**"
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Dependabot bumps fixture poms whose pinned version is the test input; #512 and #520 both fail on the bom fixture they touch. Same fix as mojohaus/license-maven-plugin@c43d4ee0, after which that repo's stream of `src/it` PRs stopped. The trees without a past PR hold fixture poms too, and are excluded pre-emptively.

Supersedes #512, #520.

*This change was created with AI assistance.*