### PR TITLE
Fix CI interpolation with custom POM elements

### DIFF
--- a/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
+++ b/src/main/java/org/codehaus/mojo/flatten/FlattenMojo.java
@@ -454,6 +454,13 @@ public class FlattenMojo extends AbstractFlattenMojo {
 
         inheritanceAssembler.flattenDependencyMode = this.flattenDependencyMode;
 
+        // Always set, not just on the resolveCiFriendliesOnly fast path below: createInterpolatedPom and
+        // createExtendedInterpolatedPom also call modelCiFriendlyInterpolator.interpolateModel(...) directly
+        // (this is the flattenMode==resolveCiFriendliesOnly branch taken when pomElements != null), and without
+        // this the pattern stays null, so CiModelInterpolator#interpolateInternal NPEs on src.contains(null).
+        ((CiModelInterpolator) this.modelCiFriendlyInterpolator)
+                .setRevisionVariablePattern(String.format("${%s}", revisionVariableName));
+
         File originalPomFile = this.project.getFile();
         Path flattenedPomFile = getFlattenedPomFile();
         Model flattenedPom;

--- a/src/main/java/org/codehaus/mojo/flatten/cifriendly/CiModelInterpolator.java
+++ b/src/main/java/org/codehaus/mojo/flatten/cifriendly/CiModelInterpolator.java
@@ -21,7 +21,6 @@ package org.codehaus.mojo.flatten.cifriendly;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.inject.Singleton;
 
 import java.io.File;
 import java.lang.reflect.Array;
@@ -65,7 +64,6 @@ import org.codehaus.plexus.interpolation.util.ValueSourceUtils;
  * Based on StringSearchModelInterpolator in maven-model-builder.
  */
 @Named
-@Singleton
 public class CiModelInterpolator implements CiInterpolator {
 
     private static final List<String> PROJECT_PREFIXES = Arrays.asList("pom.", "project.");

--- a/src/test/java/org/codehaus/mojo/flatten/FlattenMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/flatten/FlattenMojoTest.java
@@ -74,6 +74,20 @@ public class FlattenMojoTest {
         }
     }
 
+    private static final String CI_WITH_POM_ELEMENTS_PATH =
+            "src/test/resources/resolve-ci-friendlies-only-with-pom-elements/";
+    private static final String CI_WITH_POM_ELEMENTS_FLATTENED = CI_WITH_POM_ELEMENTS_PATH + ".flattened-pom.xml";
+
+    @Test
+    public void resolveCiFriendliesOnlyWithPomElementsDoesNotThrow() throws Exception {
+        MavenProject project = rule.readMavenProject(new File(CI_WITH_POM_ELEMENTS_PATH));
+        FlattenMojo flattenMojo = (FlattenMojo) rule.lookupConfiguredMojo(project, "flatten");
+
+        flattenMojo.execute();
+
+        assertThat(readPom(CI_WITH_POM_ELEMENTS_FLATTENED).getVersion()).isEqualTo("1.2.3.4");
+    }
+
     /**
      * After test method. Removes flattened-pom.xml file which is created during test.
      *
@@ -81,11 +95,14 @@ public class FlattenMojoTest {
      */
     @After
     public void removeFlattenedPom() throws IOException {
-        File flattenedPom = new File(FLATTENED_POM);
-        if (flattenedPom.exists()) {
-            if (!flattenedPom.delete()) {
-                throw new IOException("Can't delete " + flattenedPom);
-            }
+        removeFlattenedPom(FLATTENED_POM);
+        removeFlattenedPom(CI_WITH_POM_ELEMENTS_FLATTENED);
+    }
+
+    private static void removeFlattenedPom(String path) throws IOException {
+        File flattenedPom = new File(path);
+        if (flattenedPom.exists() && !flattenedPom.delete()) {
+            throw new IOException("Can't delete " + flattenedPom);
         }
     }
 }

--- a/src/test/resources/resolve-ci-friendlies-only-with-pom-elements/pom.xml
+++ b/src/test/resources/resolve-ci-friendlies-only-with-pom-elements/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.codehaus.mojo.flatten.its</groupId>
+	<artifactId>resolve-ci-friendlies-only-with-pom-elements</artifactId>
+	<version>${revision}</version>
+
+	<properties>
+		<revision>1.2.3.4</revision>
+	</properties>
+
+	<build>
+		<defaultGoal>verify</defaultGoal>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<configuration>
+					<flattenMode>resolveCiFriendliesOnly</flattenMode>
+					<pomElements>
+						<parent>remove</parent>
+					</pomElements>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>


### PR DESCRIPTION
## Problem

`resolveCiFriendliesOnly` initializes `CiModelInterpolator` only inside its no-`pomElements` fast path. Supplying a `pomElements` descriptor takes the general interpolation path with a null revision-variable pattern, causing `interpolateInternal` to fail at `src.contains(null)`.

The interpolator also stores that pattern as mutable execution state while being declared a singleton, allowing project executions to share it.

Fixes #523.

## Changes

- Initialize the configured revision-variable pattern before selecting the flattening path.
- Remove singleton scope from `CiModelInterpolator` so mutable state is execution-local.
- Add a regression fixture for `resolveCiFriendliesOnly` with an explicit `pomElements` descriptor.

## Verification

```text
jenv exec mvn -B -ntp -Dtest=FlattenMojoTest test
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```